### PR TITLE
Fix duplicate hooks file error in plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,6 +9,5 @@
   "repository": "https://github.com/jim80net/claude-skill-router",
   "license": "MIT",
   "keywords": ["skills", "memory", "semantic-search", "embeddings", "hooks"],
-  "skills": "./skills/",
-  "hooks": "./hooks/hooks.json"
+  "skills": "./skills/"
 }


### PR DESCRIPTION
## Summary
- Remove explicit `hooks` field from `.claude-plugin/plugin.json`
- `hooks/hooks.json` is auto-loaded by the plugin system; declaring it in the manifest causes a duplicate-load error

## Test plan
- [ ] Install plugin and verify no "Duplicate hooks file detected" error on load
- [ ] Verify hooks (SessionStart, UserPromptSubmit) still fire correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)