### PR TITLE
Fix workflow permissions for PR comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary
- Change `pull-requests` and `issues` permissions from `read` to `write` in both `claude-code-review.yml` and `claude.yml`
- Without write permissions, `anthropics/claude-code-action` runs Claude successfully but silently fails to post review comments to PRs

## Root cause
The GitHub API requires `pull-requests: write` to create PR comments (`POST /repos/{owner}/{repo}/pulls/{pull_number}/comments`). With read-only tokens, the API returns 403. The action exits 0 regardless, so no error surfaced — reviews were running ($2.79/run) but results were discarded.

## Test plan
- [ ] Merge this PR, then push to any open PR
- [ ] Verify Claude Code Review posts comments on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)