### PR TITLE
Add /handoff and /takeover skills for session continuity

### DIFF
--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -86,10 +86,10 @@ Capture anything that would be lost with the context window:
 Write the plan to a uniquely named file:
 
 ```
-<cwd>/.claude/handoffs/<YYYYMMDD> - <kebab-case-title>.md
+<cwd>/.claude/handoffs/<YYYYMMDD>-<kebab-case-title>.md
 ```
 
-For example: `.claude/handoffs/20260307 - prebuilt-binary-support.md`
+For example: `.claude/handoffs/20260307-prebuilt-binary-support.md`
 
 Use this structure:
 
@@ -145,14 +145,14 @@ Show the handoff document and ask:
 
 Update the file with any corrections.
 
-### 8. Tell the user how to resume
+### 8. Tell the user how to take over
 
 Print the exact command or prompt to start the next session, including the full filename:
 
 ```
-To resume, start a new session and say:
+To continue, start a new session and say:
 
-  Read .claude/handoffs/<YYYYMMDD> - <title>.md and continue from where we left off.
+  /takeover .claude/handoffs/<YYYYMMDD>-<title>.md
 ```
 
 ## Guidelines

--- a/skills/takeover/SKILL.md
+++ b/skills/takeover/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: takeover
+description: "Pick up where a previous session left off by reading and executing a handoff document."
+queries:
+  - "take over from handoff"
+  - "continue where we left off"
+  - "pick up previous work"
+  - "load handoff"
+  - "what was I working on"
+  - "takeover previous session"
+  - "continue from last session"
+---
+
+# /takeover — Continue from a Handoff
+
+Read a handoff document and orient the session to continue the work.
+
+## Process
+
+### 1. Find the handoff
+
+List available handoff documents:
+
+```bash
+ls -1t .claude/handoffs/*.md 2>/dev/null
+```
+
+If the user specified a filename, use that. Otherwise show the list sorted by date (newest first) and ask which one to take over.
+
+### 2. Read and internalize
+
+Read the handoff file completely. Before proceeding, understand:
+
+- **Objective** — what are we trying to accomplish?
+- **Completed** — what's already done? Don't redo this.
+- **Remaining** — what's the task list?
+- **Current state** — what branch, what's uncommitted?
+- **Key decisions** — what was decided and why? Honor these unless the user says otherwise.
+- **Gotchas** — what to watch out for?
+
+### 3. Verify current state
+
+Confirm the working environment matches what the handoff expects:
+
+```bash
+git branch --show-current
+git status
+git log --oneline -5
+```
+
+If the branch or state doesn't match (e.g., switched branches since the handoff), flag it and ask the user how to proceed.
+
+### 4. Understand the objective
+
+Before presenting a plan, make sure you genuinely understand the goal. Ask clarifying questions if:
+
+- The objective is ambiguous or could be interpreted multiple ways
+- The remaining tasks seem disconnected from the stated objective
+- Key decisions reference context you don't have (e.g., external specs, ticket numbers)
+- The gotchas suggest complexity that isn't reflected in the remaining tasks
+
+Do not proceed until you're confident you understand what success looks like.
+
+### 5. Present the plan
+
+Give the user a brief summary:
+
+> **Taking over:** <title>
+> **Branch:** <branch>
+> **Next up:** <first remaining task>
+>
+> <N> items remaining. Shall I start with <first item>?
+
+### 6. Begin work
+
+Start executing the remaining tasks in order. Follow the suggested approaches noted in the handoff. Respect the key decisions unless the user overrides them.
+
+$ARGUMENTS


### PR DESCRIPTION
## Summary

Adds a paired set of skills for passing work between sessions:

**`/handoff`** — Captures the full state of in-progress work and writes a structured continuation plan to `.claude/handoffs/<YYYYMMDD>-<title>.md`:
- Objective, completed work, remaining tasks
- Current git state (branch, uncommitted changes, open PRs)
- Key decisions with rationale
- Failed approaches (so the next session doesn't retry them)
- Gotchas and environment quirks

**`/takeover`** — Reads a handoff document and orients a fresh session:
1. Finds and reads the handoff
2. Verifies the working environment matches
3. Asks clarifying questions to understand the objective before proceeding
4. Presents a plan and begins work

**Full skill family:** `/sleep`, `/deep-sleep`, `/reflect`, `/handoff`, `/takeover`

## Test plan

- [x] 68 tests pass
- [x] Follows existing SKILL.md format conventions
- [ ] Manually test handoff → takeover flow across two sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)