### PR TITLE
feat: Phase 2 portable-location wiring for claude adapter (memex-core#32)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
-    "@jim80net/memex-core": "^0.4.0"
+    "@jim80net/memex-core": "^0.5.0"
   },
   "packageManager": "pnpm@9.15.0",
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^3.8.1
         version: 3.8.1
       '@jim80net/memex-core':
-        specifier: ^0.4.0
-        version: 0.4.0
+        specifier: ^0.5.0
+        version: 0.5.0
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -200,8 +200,8 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
-  '@jim80net/memex-core@0.4.0':
-    resolution: {integrity: sha512-OuY1Ff051w0HlqTQAs5ZYXB4ve7ziPIJ9aVpjs2Qhf5XGJMlf8dkydXhN9jKmvlovfJQkHPPSiPjJQra0icCsA==}
+  '@jim80net/memex-core@0.5.0':
+    resolution: {integrity: sha512-a8DIxsFk0WCDhZesfAQUbIgTNgfrCSzhxGSKKlC7l9paFx0gmzhmoFFJc7BYPGVfbJZRENC5Uoyp4JMgt0THZA==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -856,7 +856,7 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@jim80net/memex-core@0.4.0':
+  '@jim80net/memex-core@0.5.0':
     optionalDependencies:
       '@huggingface/transformers': 3.8.1
 

--- a/src/core/scan-roots.ts
+++ b/src/core/scan-roots.ts
@@ -1,0 +1,64 @@
+import { join } from "node:path";
+import {
+  buildScanRoots,
+  findMatchingProjectMemoryDirs,
+  getSyncScanDirs,
+} from "@jim80net/memex-core";
+import type { ScanDirs, ScanRootRegistry, SyncConfig } from "@jim80net/memex-core";
+import type { ClaudePaths } from "./paths.ts";
+import {
+  getProjectMemoryDir,
+  getProjectRulesDir,
+  getProjectSkillsDir,
+} from "./paths.ts";
+
+/** Assemble scan directories — mirrors src/main.ts wiring. */
+export async function assembleClaudeScanDirs(
+  cwd: string,
+  paths: Pick<ClaudePaths, "globalSkillsDir" | "globalRulesDir" | "projectsDir" | "syncRepoDir">,
+  extraSkillDirs: string[],
+  syncConfig: SyncConfig,
+): Promise<ScanDirs> {
+  const scanDirs: ScanDirs = {
+    skillDirs: [paths.globalSkillsDir, getProjectSkillsDir(cwd), ...extraSkillDirs],
+    memoryDirs: [getProjectMemoryDir(cwd, paths.projectsDir)],
+    ruleDirs: [paths.globalRulesDir, getProjectRulesDir(cwd)],
+  };
+
+  if (syncConfig.enabled) {
+    const syncDirs = getSyncScanDirs(paths.syncRepoDir);
+    scanDirs.skillDirs.push(syncDirs.skillsDir);
+    scanDirs.ruleDirs.push(syncDirs.rulesDir);
+
+    const syncMemDirs = await findMatchingProjectMemoryDirs(
+      cwd,
+      paths.syncRepoDir,
+      syncConfig,
+    );
+    scanDirs.memoryDirs.push(...syncMemDirs);
+  }
+
+  return scanDirs;
+}
+
+/** Labeled scan roots for portable memex:// handles (harness: claude). */
+export function buildClaudeScanRoots(
+  cwd: string,
+  paths: Pick<ClaudePaths, "globalSkillsDir" | "globalRulesDir" | "syncRepoDir">,
+  scanDirs: ScanDirs,
+  syncEnabled: boolean,
+): ScanRootRegistry {
+  return buildScanRoots(
+    {
+      cwd,
+      syncRepoDir: paths.syncRepoDir,
+      syncEnabled,
+      globalSkillsDirs: [paths.globalSkillsDir],
+      globalRulesDirs: [paths.globalRulesDir],
+      projectSkillsDir: getProjectSkillsDir(cwd),
+      projectRulesDir: getProjectRulesDir(cwd),
+      harness: "claude",
+    },
+    scanDirs,
+  );
+}

--- a/src/hooks/user-prompt.ts
+++ b/src/hooks/user-prompt.ts
@@ -1,6 +1,12 @@
-import type { SkillIndex } from "@jim80net/memex-core";
+import type { SkillIndex, ScanRootRegistry } from "@jim80net/memex-core";
 import type { HookInput, HookOutput } from "@jim80net/memex-core";
-import { loadTelemetry, saveTelemetry, recordMatch, withFileLock } from "@jim80net/memex-core";
+import {
+  loadTelemetry,
+  saveTelemetry,
+  recordMatch,
+  withFileLock,
+  resolvePortableLocationResolved,
+} from "@jim80net/memex-core";
 import type { HookConfig, AutoMemoryMode } from "../core/config.ts";
 import { loadSession, saveSession, hasRuleBeenShown, markRuleShown } from "../core/session.ts";
 import { getClaudePaths } from "../core/paths.ts";
@@ -9,7 +15,8 @@ export async function handleUserPrompt(
   input: HookInput,
   index: SkillIndex,
   hookConfig: HookConfig,
-  autoMemoryMode: AutoMemoryMode
+  autoMemoryMode: AutoMemoryMode,
+  registry: ScanRootRegistry,
 ): Promise<HookOutput> {
   const prompt = input.prompt;
   if (!prompt || prompt.trim().length === 0) return {};
@@ -72,8 +79,12 @@ export async function handleUserPrompt(
       }
       section = `## Recalled Memory: ${skill.name} (relevance: ${relevance})\n\n${content}`;
     } else {
-      // Skill, workflow, tool-guidance: description teaser only
-      section = `## Available Skill: ${skill.name} (relevance: ${relevance})\n\n**${skill.name}**: ${skill.description}\n\nTo use this skill, read the full instructions at: \`${skill.location}\``;
+      const { filePath: displayPath } = resolvePortableLocationResolved(
+        registry,
+        skill.location,
+        { allowAbsolute: true },
+      );
+      section = `## Available Skill: ${skill.name} (relevance: ${relevance})\n\n**${skill.name}**: ${skill.description}\n\nTo use this skill, read the full instructions at: \`${displayPath}\``;
     }
 
     if (totalChars + section.length > hookConfig.maxInjectedChars) break;

--- a/src/hooks/user-prompt.ts
+++ b/src/hooks/user-prompt.ts
@@ -79,11 +79,16 @@ export async function handleUserPrompt(
       }
       section = `## Recalled Memory: ${skill.name} (relevance: ${relevance})\n\n${content}`;
     } else {
-      const { filePath: displayPath } = resolvePortableLocationResolved(
-        registry,
-        skill.location,
-        { allowAbsolute: true },
-      );
+      let displayPath: string;
+      try {
+        ({ filePath: displayPath } = resolvePortableLocationResolved(
+          registry,
+          skill.location,
+          { allowAbsolute: true },
+        ));
+      } catch {
+        displayPath = skill.location;
+      }
       section = `## Available Skill: ${skill.name} (relevance: ${relevance})\n\n**${skill.name}**: ${skill.description}\n\nTo use this skill, read the full instructions at: \`${displayPath}\``;
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,19 +1,10 @@
 #!/usr/bin/env node
 import { join } from "node:path";
-import {
-  SkillIndex,
-  LocalEmbeddingProvider,
-  getSyncScanDirs,
-  findMatchingProjectMemoryDirs,
-} from "@jim80net/memex-core";
-import type { HookInput, HookOutput, ScanDirs } from "@jim80net/memex-core";
+import { SkillIndex, LocalEmbeddingProvider } from "@jim80net/memex-core";
+import type { HookInput, HookOutput } from "@jim80net/memex-core";
 import { loadConfig } from "./core/config.ts";
-import {
-  getClaudePaths,
-  getProjectMemoryDir,
-  getProjectSkillsDir,
-  getProjectRulesDir,
-} from "./core/paths.ts";
+import { getClaudePaths } from "./core/paths.ts";
+import { assembleClaudeScanDirs, buildClaudeScanRoots } from "./core/scan-roots.ts";
 import { handleUserPrompt } from "./hooks/user-prompt.ts";
 import { handleStop } from "./hooks/stop.ts";
 import { handlePreToolUse } from "./hooks/pre-tool-use.ts";
@@ -51,28 +42,15 @@ async function main(): Promise<void> {
   // Construct core objects
   const provider = new LocalEmbeddingProvider(config.embeddingModel, paths.modelsDir);
   const cachePath = join(paths.cacheDir, "memex-cache.json");
-  const index = new SkillIndex(config, provider, cachePath);
 
-  // Build scan dirs from claude-specific paths
-  const scanDirs: ScanDirs = {
-    skillDirs: [paths.globalSkillsDir, getProjectSkillsDir(cwd), ...config.skillDirs],
-    memoryDirs: [getProjectMemoryDir(cwd, paths.projectsDir)],
-    ruleDirs: [paths.globalRulesDir, getProjectRulesDir(cwd)],
-  };
-
-  // Add sync repo scan paths if sync is enabled
-  if (config.sync.enabled) {
-    const syncDirs = getSyncScanDirs(paths.syncRepoDir);
-    scanDirs.skillDirs.push(syncDirs.skillsDir);
-    scanDirs.ruleDirs.push(syncDirs.rulesDir);
-
-    const syncMemDirs = await findMatchingProjectMemoryDirs(
-      cwd,
-      paths.syncRepoDir,
-      config.sync,
-    );
-    scanDirs.memoryDirs.push(...syncMemDirs);
-  }
+  const scanDirs = await assembleClaudeScanDirs(
+    cwd,
+    paths,
+    config.skillDirs,
+    config.sync,
+  );
+  const registry = buildClaudeScanRoots(cwd, paths, scanDirs, config.sync.enabled);
+  const index = new SkillIndex(config, provider, cachePath, { registry });
 
   // Build index (will use cache for unchanged files)
   try {
@@ -94,7 +72,13 @@ async function main(): Promise<void> {
 
       case "UserPromptSubmit":
         if (config.hooks.UserPromptSubmit.enabled) {
-          result = await handleUserPrompt(input, index, config.hooks.UserPromptSubmit, config.autoMemoryMode);
+          result = await handleUserPrompt(
+            input,
+            index,
+            config.hooks.UserPromptSubmit,
+            config.autoMemoryMode,
+            registry,
+          );
         }
         break;
 

--- a/test/cross-adapter-pin-alignment.test.ts
+++ b/test/cross-adapter-pin-alignment.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const CROSS_ADAPTER_TRANSFORMERS_RANGE = "^3.8.1";
+const CROSS_ADAPTER_TRANSFORMERS_RESOLVED = "3.8.1";
+const CROSS_ADAPTER_MEMEX_CORE_RANGE = "^0.5.0";
+const CROSS_ADAPTER_MEMEX_CORE_RESOLVED = "0.5.0";
+
+function readJson(relFromRepoRoot: string): Record<string, unknown> {
+  const url = new URL(`../${relFromRepoRoot}`, import.meta.url);
+  return JSON.parse(readFileSync(fileURLToPath(url), "utf-8")) as Record<string, unknown>;
+}
+
+function depRange(pkg: Record<string, unknown>, name: string): string | undefined {
+  for (const field of ["dependencies", "optionalDependencies", "peerDependencies"]) {
+    const block = pkg[field];
+    if (block && typeof block === "object") {
+      const v = (block as Record<string, string>)[name];
+      if (typeof v === "string") return v;
+    }
+  }
+  return undefined;
+}
+
+describe("cross-adapter version-pin alignment (memex-core#32)", () => {
+  const claudePkg = readJson("package.json");
+
+  it("@jim80net/memex-core range", () => {
+    expect(depRange(claudePkg, "@jim80net/memex-core")).toBe(CROSS_ADAPTER_MEMEX_CORE_RANGE);
+  });
+
+  it("the INSTALLED @jim80net/memex-core version equals the reference", () => {
+    const installed = readJson("node_modules/@jim80net/memex-core/package.json");
+    expect(installed.version).toBe(CROSS_ADAPTER_MEMEX_CORE_RESOLVED);
+  });
+
+  it("@huggingface/transformers range matches memex-core", () => {
+    const corePkg = readJson("node_modules/@jim80net/memex-core/package.json");
+    const coreRange = depRange(corePkg, "@huggingface/transformers");
+    expect(coreRange).toBeDefined();
+    expect(depRange(claudePkg, "@huggingface/transformers")).toBe(coreRange);
+    expect(CROSS_ADAPTER_TRANSFORMERS_RANGE).toBe(coreRange);
+    const installed = readJson("node_modules/@huggingface/transformers/package.json");
+    expect(installed.version).toBe(CROSS_ADAPTER_TRANSFORMERS_RESOLVED);
+  });
+});

--- a/test/fixtures/cross-adapter/location-round-trip-golden.ts
+++ b/test/fixtures/cross-adapter/location-round-trip-golden.ts
@@ -1,0 +1,23 @@
+/** Golden vectors for cross-adapter location-handle conformance guards (memex-core#32). */
+export const LOCATION_ROUND_TRIP_GOLDEN = [
+  {
+    label: "grok-global skill",
+    absolute: "/home/user/.grok/skills/weather/SKILL.md",
+    handle: "memex://grok-global/weather/SKILL.md",
+  },
+  {
+    label: "grok-project skill",
+    absolute: "/home/user/project/.grok/skills/deploy/SKILL.md",
+    handle: "memex://grok-project/deploy/SKILL.md",
+  },
+  {
+    label: "sync-skills copy",
+    absolute: "/home/user/.memex/sync/skills/weather/SKILL.md",
+    handle: "memex://sync-skills/weather/SKILL.md",
+  },
+  {
+    label: "unclassified extra dir (path-hash stable)",
+    absolute: "/opt/extra/skills/custom/SKILL.md",
+    handle: "memex://skill-unclassified-067ae16e/custom/SKILL.md",
+  },
+] as const;

--- a/test/location-round-trip-golden.test.ts
+++ b/test/location-round-trip-golden.test.ts
@@ -1,0 +1,45 @@
+// Cross-adapter location-handle conformance guard (memex-core#32 freeze-SHA memo).
+// Golden bytes vendored from memex-core test/fixtures at freeze tag memex-core-v0.5.0.
+
+import { describe, expect, it } from "vitest";
+import {
+  buildScanRoots,
+  decodePortableLocation,
+  encodePortableLocation,
+  type ScanRootContext,
+} from "@jim80net/memex-core";
+import { LOCATION_ROUND_TRIP_GOLDEN } from "./fixtures/cross-adapter/location-round-trip-golden.ts";
+
+const FIXTURE_CTX: ScanRootContext = {
+  cwd: "/home/user/project",
+  syncEnabled: true,
+  syncRepoDir: "/home/user/.memex/sync",
+  globalSkillsDirs: ["/home/user/.grok/skills", "/home/user/.claude/skills"],
+  globalRulesDirs: ["/home/user/.grok/rules"],
+  projectSkillsDir: "/home/user/project/.grok/skills",
+  projectRulesDir: "/home/user/project/.grok/rules",
+  harness: "grok",
+};
+
+function fixtureRegistry() {
+  return buildScanRoots(FIXTURE_CTX, {
+    skillDirs: [
+      "/home/user/.grok/skills",
+      "/home/user/project/.grok/skills",
+      "/home/user/.memex/sync/skills",
+      "/opt/extra/skills",
+    ],
+    memoryDirs: ["/home/user/project/.grok/memories"],
+    ruleDirs: ["/home/user/.grok/rules", "/home/user/.memex/sync/rules"],
+  });
+}
+
+describe("location round-trip golden (memex-core#32 conformance)", () => {
+  it("round-trips golden vectors against pinned memex-core", () => {
+    const registry = fixtureRegistry();
+    for (const { absolute, handle } of LOCATION_ROUND_TRIP_GOLDEN) {
+      expect(encodePortableLocation(registry, absolute)).toBe(handle);
+      expect(decodePortableLocation(registry, handle)).toBe(absolute);
+    }
+  });
+});

--- a/test/portable-read.test.ts
+++ b/test/portable-read.test.ts
@@ -1,0 +1,75 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_CORE_CONFIG,
+  SkillIndex,
+  encodePortableLocation,
+} from "@jim80net/memex-core";
+import type { EmbeddingProvider } from "@jim80net/memex-core";
+import { buildClaudeScanRoots } from "../src/core/scan-roots.ts";
+
+const SKILL_BODY = "Use the weather API with the user's preferred units.";
+
+describe("portable handle read path", () => {
+  let root: string;
+  let cwd: string;
+  let claudeHome: string;
+  let globalSkillsDir: string;
+  let cachePath: string;
+  let mockEmbed: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    root = join(tmpdir(), `portable-read-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    cwd = join(root, "workspace");
+    claudeHome = join(root, ".claude");
+    globalSkillsDir = join(claudeHome, "skills");
+    cachePath = join(claudeHome, "cache", "memex-cache.json");
+
+    await mkdir(join(globalSkillsDir, "weather"), { recursive: true });
+    await writeFile(
+      join(globalSkillsDir, "weather", "SKILL.md"),
+      `---
+name: weather
+description: Weather lookups
+---
+${SKILL_BODY}
+`,
+      "utf-8",
+    );
+
+    mockEmbed = vi.fn().mockResolvedValue([[1, 0, 0, 0]]);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("index stores portable handles and readSkillContent round-trips them", async () => {
+    const paths = {
+      globalSkillsDir,
+      globalRulesDir: join(claudeHome, "rules"),
+      syncRepoDir: join(root, "sync"),
+    };
+    const scanDirs = {
+      skillDirs: [globalSkillsDir, join(cwd, ".claude", "skills")],
+      memoryDirs: [join(claudeHome, "projects", "x", "memory")],
+      ruleDirs: [paths.globalRulesDir],
+    };
+    const registry = buildClaudeScanRoots(cwd, paths, scanDirs, false);
+
+    const skillPath = join(globalSkillsDir, "weather", "SKILL.md");
+    const handle = encodePortableLocation(registry, skillPath);
+    expect(handle).toBe("memex://claude-global/weather/SKILL.md");
+
+    const provider: EmbeddingProvider = { embed: mockEmbed };
+    const index = new SkillIndex({ ...DEFAULT_CORE_CONFIG }, provider, cachePath, {
+      registry,
+    });
+    await index.build(scanDirs);
+
+    const body = await index.readSkillContent(handle!);
+    expect(body).toBe(SKILL_BODY);
+  });
+});

--- a/test/scan-roots.test.ts
+++ b/test/scan-roots.test.ts
@@ -1,0 +1,48 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  encodePortableLocation,
+  decodePortableLocation,
+} from "@jim80net/memex-core";
+import { buildClaudeScanRoots } from "../src/core/scan-roots.ts";
+
+describe("buildClaudeScanRoots", () => {
+  const cwd = "/home/user/project";
+  const claudeHome = "/home/user/.claude";
+  const syncRepoDir = "/home/user/.local/share/memex-claude";
+
+  it("labels claude-global, claude-project, and sync-skills roots", () => {
+    const paths = {
+      globalSkillsDir: join(claudeHome, "skills"),
+      globalRulesDir: join(claudeHome, "rules"),
+      syncRepoDir,
+    };
+    const scanDirs = {
+      skillDirs: [
+        paths.globalSkillsDir,
+        join(cwd, ".claude", "skills"),
+        join(syncRepoDir, "skills"),
+      ],
+      memoryDirs: [join(claudeHome, "projects", "abc", "memory")],
+      ruleDirs: [paths.globalRulesDir, join(syncRepoDir, "rules")],
+    };
+
+    const registry = buildClaudeScanRoots(cwd, paths, scanDirs, true);
+
+    const globalSkill = join(claudeHome, "skills", "weather", "SKILL.md");
+    const projectSkill = join(cwd, ".claude", "skills", "deploy", "SKILL.md");
+    const syncSkill = join(syncRepoDir, "skills", "weather", "SKILL.md");
+
+    const globalHandle = encodePortableLocation(registry, globalSkill);
+    const projectHandle = encodePortableLocation(registry, projectSkill);
+    const syncHandle = encodePortableLocation(registry, syncSkill);
+
+    expect(globalHandle).toBe("memex://claude-global/weather/SKILL.md");
+    expect(projectHandle).toBe("memex://claude-project/deploy/SKILL.md");
+    expect(syncHandle).toBe("memex://sync-skills/weather/SKILL.md");
+
+    expect(decodePortableLocation(registry, globalHandle!)).toBe(globalSkill);
+    expect(decodePortableLocation(registry, projectHandle!)).toBe(projectSkill);
+    expect(decodePortableLocation(registry, syncHandle!)).toBe(syncSkill);
+  });
+});

--- a/test/user-prompt.test.ts
+++ b/test/user-prompt.test.ts
@@ -340,6 +340,50 @@ describe("handleUserPrompt", () => {
     expect(result.additionalContext).toBeUndefined();
   });
 
+  it("skill teaser with unknown-root handle degrades to raw location without dropping other results", async () => {
+    const unknownHandle = "memex://stale-catalog-key/weather/SKILL.md";
+    const registry = [{ key: "claude-global", rootPath: "/home/user/.claude/skills" }];
+
+    const matches: SkillSearchResult[] = [
+      {
+        skill: {
+          name: "stale-skill",
+          description: "Cached from old host",
+          location: unknownHandle,
+          type: "skill",
+          embeddings: [],
+          queries: [],
+        },
+        score: 0.95,
+        bestQueryIndex: 0,
+      },
+      {
+        skill: {
+          name: "prefer-bun",
+          description: "Use bun over npm",
+          location: "/fake/skills/bun/SKILL.md",
+          type: "memory",
+          embeddings: [],
+          queries: [],
+        },
+        score: 0.88,
+        bestQueryIndex: 0,
+      },
+    ];
+    const index = makeIndex({
+      search: vi.fn().mockResolvedValue(matches),
+      readSkillContent: vi.fn().mockResolvedValue("Use bun instead of npm."),
+    });
+
+    const result = await handleUserPrompt(BASE_INPUT, index, BASE_CONFIG, "takeover", registry);
+
+    expect(result.additionalContext).toBeDefined();
+    expect(result.additionalContext).toContain("Recalled Memory: prefer-bun");
+    expect(result.additionalContext).toContain("Use bun instead of npm.");
+    expect(result.additionalContext).toContain("Available Skill: stale-skill");
+    expect(result.additionalContext).toContain(unknownHandle);
+  });
+
   it("skill teaser resolves memex:// handle to absolute path for display", async () => {
     const absolute = "/home/user/.claude/skills/weather/SKILL.md";
     const handle = "memex://claude-global/weather/SKILL.md";

--- a/test/user-prompt.test.ts
+++ b/test/user-prompt.test.ts
@@ -70,7 +70,7 @@ describe("handleUserPrompt", () => {
 
   it("returns empty when no skills match", async () => {
     const index = makeIndex({ search: vi.fn().mockResolvedValue([]) });
-    const result = await handleUserPrompt(BASE_INPUT, index, BASE_CONFIG, "takeover");
+    const result = await handleUserPrompt(BASE_INPUT, index, BASE_CONFIG, "takeover", []);
     expect(result.additionalContext).toBeUndefined();
   });
 
@@ -80,7 +80,8 @@ describe("handleUserPrompt", () => {
       { ...BASE_INPUT, prompt: "" },
       index,
       BASE_CONFIG,
-      "takeover"
+      "takeover",
+      [],
     );
     expect(result.additionalContext).toBeUndefined();
   });
@@ -103,7 +104,7 @@ describe("handleUserPrompt", () => {
       readSkillContent: vi.fn().mockResolvedValue("# Weather\n\nFetch weather data."),
     });
 
-    const result = await handleUserPrompt(BASE_INPUT, index, BASE_CONFIG, "takeover");
+    const result = await handleUserPrompt(BASE_INPUT, index, BASE_CONFIG, "takeover", []);
 
     expect(result.additionalContext).toBeDefined();
     expect(result.additionalContext).toContain("Available Skill: weather");
@@ -131,7 +132,7 @@ describe("handleUserPrompt", () => {
       readSkillContent: vi.fn().mockResolvedValue("Use bun instead of npm."),
     });
 
-    const result = await handleUserPrompt(BASE_INPUT, index, BASE_CONFIG, "takeover");
+    const result = await handleUserPrompt(BASE_INPUT, index, BASE_CONFIG, "takeover", []);
 
     expect(result.additionalContext).toContain("Recalled Memory: prefer-bun");
     expect(result.additionalContext).toContain("Use bun instead of npm.");
@@ -159,7 +160,7 @@ describe("handleUserPrompt", () => {
       readSkillContent: vi.fn().mockResolvedValue("Always use pnpm for package management.\n- pnpm install\n- pnpm add <pkg>"),
     });
 
-    const result = await handleUserPrompt(BASE_INPUT, index, BASE_CONFIG, "takeover");
+    const result = await handleUserPrompt(BASE_INPUT, index, BASE_CONFIG, "takeover", []);
 
     expect(result.additionalContext).toContain("Rule: prefer-pnpm");
     expect(result.additionalContext).toContain("Always use pnpm for package management.");
@@ -186,7 +187,7 @@ describe("handleUserPrompt", () => {
       search: vi.fn().mockResolvedValue([match]),
     });
 
-    const result = await handleUserPrompt(BASE_INPUT, index, BASE_CONFIG, "takeover");
+    const result = await handleUserPrompt(BASE_INPUT, index, BASE_CONFIG, "takeover", []);
 
     expect(result.additionalContext).toContain("Rule reminder: prefer-pnpm");
     expect(result.additionalContext).toContain("Use pnpm, not npm.");
@@ -215,7 +216,7 @@ describe("handleUserPrompt", () => {
     const result = await handleUserPrompt(BASE_INPUT, index, {
       ...BASE_CONFIG,
       maxInjectedChars: 6000,
-    }, "takeover");
+    }, "takeover", []);
 
     expect(result.additionalContext).toContain("skill-a");
     expect(result.additionalContext).not.toContain("skill-b");
@@ -228,7 +229,7 @@ describe("handleUserPrompt", () => {
     await handleUserPrompt(BASE_INPUT, index, {
       ...BASE_CONFIG,
       types: ["memory", "workflow"],
-    }, "takeover");
+    }, "takeover", []);
 
     expect(searchFn).toHaveBeenCalledWith(
       BASE_INPUT.prompt,
@@ -259,7 +260,7 @@ describe("handleUserPrompt", () => {
         .mockResolvedValueOnce("Good content"),
     });
 
-    const result = await handleUserPrompt(BASE_INPUT, index, BASE_CONFIG, "takeover");
+    const result = await handleUserPrompt(BASE_INPUT, index, BASE_CONFIG, "takeover", []);
 
     expect(result.additionalContext).toContain("good");
     expect(result.additionalContext).not.toContain("bad");
@@ -286,7 +287,7 @@ describe("handleUserPrompt", () => {
       readSkillContent: vi.fn().mockResolvedValue("Test content"),
     });
 
-    await handleUserPrompt(BASE_INPUT, index, BASE_CONFIG, "takeover");
+    await handleUserPrompt(BASE_INPUT, index, BASE_CONFIG, "takeover", []);
 
     expect(recordMatch).toHaveBeenCalledWith(
       expect.any(Object),
@@ -300,7 +301,7 @@ describe("handleUserPrompt", () => {
     const searchFn = vi.fn().mockResolvedValue([]);
     const index = makeIndex({ search: searchFn });
 
-    await handleUserPrompt(BASE_INPUT, index, BASE_CONFIG, "assist");
+    await handleUserPrompt(BASE_INPUT, index, BASE_CONFIG, "assist", []);
 
     // Should strip "memory" and "session-learning" from the types list
     expect(searchFn).toHaveBeenCalledWith(
@@ -315,7 +316,7 @@ describe("handleUserPrompt", () => {
     const searchFn = vi.fn().mockResolvedValue([]);
     const index = makeIndex({ search: searchFn });
 
-    await handleUserPrompt(BASE_INPUT, index, BASE_CONFIG, "takeover");
+    await handleUserPrompt(BASE_INPUT, index, BASE_CONFIG, "takeover", []);
 
     expect(searchFn).toHaveBeenCalledWith(
       BASE_INPUT.prompt,
@@ -332,9 +333,39 @@ describe("handleUserPrompt", () => {
       BASE_INPUT,
       index,
       { ...BASE_CONFIG, types: ["memory", "session-learning"] },
-      "assist"
+      "assist",
+      [],
     );
 
     expect(result.additionalContext).toBeUndefined();
+  });
+
+  it("skill teaser resolves memex:// handle to absolute path for display", async () => {
+    const absolute = "/home/user/.claude/skills/weather/SKILL.md";
+    const handle = "memex://claude-global/weather/SKILL.md";
+    const registry = [
+      { key: "claude-global", rootPath: "/home/user/.claude/skills" },
+    ];
+
+    const match: SkillSearchResult = {
+      skill: {
+        name: "weather",
+        description: "Get weather forecasts",
+        location: handle,
+        type: "skill",
+        embeddings: [],
+        queries: [],
+      },
+      score: 0.92,
+      bestQueryIndex: 0,
+    };
+    const index = makeIndex({
+      search: vi.fn().mockResolvedValue([match]),
+    });
+
+    const result = await handleUserPrompt(BASE_INPUT, index, BASE_CONFIG, "takeover", registry);
+
+    expect(result.additionalContext).toContain(absolute);
+    expect(result.additionalContext).not.toContain(handle);
   });
 });


### PR DESCRIPTION
## Summary

memex-claude Phase 2 portable-location slice (freeze memo: memex-core#32 issuecomment-4898067215). Same shape as merged memex-codex #10 — hook-based adapter, no MCP read-tool / #19 surface.

**Base: `main`** (claude foundation is on main; unlike grok → `impl/foundation`).

## Deliverables

1. Pin `@jim80net/memex-core` `^0.4.0` → `^0.5.0`
2. `src/core/scan-roots.ts` — `assembleClaudeScanDirs` + `buildClaudeScanRoots(harness:"claude")`
3. `src/main.ts` — `{ registry }` into `SkillIndex`; registry passed to `handleUserPrompt`
4. `src/hooks/user-prompt.ts` — teaser resolves `memex://` → absolute via `resolvePortableLocationResolved.filePath`
5. CI guards: location round-trip golden, scan-roots labeling, portable-read round-trip, pin-alignment

Read paths already route through `index.readSkillContent` — no raw `readFile(.location)`.

## Desk gate table

| Gate | Status |
|------|--------|
| `pnpm typecheck` | green |
| `pnpm test` | **44 passed** |
| golden conformance | green |
| claude scan-roots labeling | `scan-roots.test.ts` |
| teaser dead-link fix | `user-prompt.test.ts` |
| pin `^0.5.0` | `cross-adapter-pin-alignment.test.ts` |
| no self-merge | awaiting memex XO wave gate |

## Lockstep

Adapter 3 of 4 — hermes follows after this merges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Phase 2 portable-location support for the Claude adapter with a scan-root registry for `memex://` handles, wired through the index and prompt hooks. Adds fail-open handling for unknown registry keys in skill teasers and bumps `@jim80net/memex-core` to `^0.5.0`.

- **New Features**
  - Added `assembleClaudeScanDirs` and `buildClaudeScanRoots` to create labeled scan roots (harness: claude).
  - Passed `{ registry }` into `SkillIndex` and into `handleUserPrompt`.
  - Skill teasers resolve `memex://` to absolute paths via `resolvePortableLocationResolved`.
  - Added guards: location round-trip golden, portable-read path, scan-roots labeling, and cross-adapter pin-alignment.

- **Bug Fixes**
  - Skill teaser decode no longer aborts on unknown/stale `memex://` root; falls back to raw `skill.location` (regression test added).

<sup>Written for commit 3f03a855c184f6680e8f3501cb5c9a5738aeaf9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jim80net/memex-claude/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

