### PR TITLE
feat(projection): G3 shared-origin rules via memex-core@0.6.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,10 +18,12 @@ bun run build.ts     # compile standalone binary
 - `@jim80net/memex-core` — Shared engine (separate repo): embeddings (ONNX + OpenAI), skill-index, cache, config, session, telemetry, sync, project-mapping, project-registry, file-lock, traces, types
 - `src/core/` — Claude-specific wrappers:
   - `paths.ts` — Claude path configuration (`~/.claude/...`)
-  - `config.ts` — Extends `MemexCoreConfig` with hook-specific config, sync, sleep schedule
+  - `config.ts` — Extends `MemexCoreConfig` with hook-specific config, sync (`repoDir?`), sleep schedule
+  - `projection.ts` — G3 thin adapter: `resolveOriginRoot` / `planProjection` / `applyProjection` into `~/.claude/rules`
+  - `scan-roots.ts` — ScanDirs assembly + portable handle registry (skips raw origin/rules when projecting)
   - `session.ts` — File-based session persistence (wraps core's `SessionTracker` interface)
 - `src/hooks/` — Hook handlers: user-prompt, pre-tool-use, stop, pre-compact, session-start
-- `src/main.ts` — Entry point: constructs `SkillIndex`, `LocalEmbeddingProvider`, `ScanDirs`, dispatches by `hook_event_name`
+- `src/main.ts` — Entry point: SessionStart pull+project early; other events build `SkillIndex` and dispatch
 - `bin/` — Wrapper scripts (memex, memex.cmd, install.sh, sleep-schedule.sh)
 - `build.ts` — Build script: compiles standalone binary via bun, stubs sharp, bundles ONNX
 - `skills/` — Bundled skill definitions (sleep, deep-sleep, doctor, handoff, takeover, memory-creation)
@@ -35,7 +37,7 @@ bun run build.ts     # compile standalone binary
 | Skills | `~/.claude/skills/*/SKILL.md` | `<cwd>/.claude/skills/*/SKILL.md` | `<sync-repo>/skills/*/SKILL.md` |
 | Memory | `~/.claude/projects/<encoded-cwd>/memory/*.md` | — | `<sync-repo>/projects/<canonical-id>/memory/*.md` |
 
-When sync is enabled, the sync repo at `~/.local/share/memex-claude/` is scanned alongside local paths.
+When sync is enabled, origin skills/memories are scanned alongside harness paths. When **rules projection** is active (`sync.enabled`), origin `rules/` is **not** double-scanned — harness `~/.claude/rules` holds symlinks into origin (pin `@jim80net/memex-core@^0.6.0`).
 
 ### Disclosure model
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -218,24 +218,26 @@ The router can sync your growing corpus of rules, skills, and memories across wo
 
 ### How it works
 
-- **Session start**: pulls latest changes from the remote repo (`git pull --rebase`)
-- **Session end**: copies new/changed rules, skills, and memories into the sync repo, commits, and pushes
-- **Conflict resolution**: markdown conflicts are auto-resolved by keeping both sides
+- **Session start**: resolves the shared origin (`resolveOriginRoot` — product default `~/.memex`, with legacy `~/.local/share/memex-claude` still valid), pulls when a remote is configured, then **projects** origin rules into `~/.claude/rules` as absolute symlinks (fail-closed: real files are never overwritten)
+- **Session end** (when Stop hook + `autoCommitPush` are enabled): copies local-only changes into the origin and pushes; managed rule symlinks are skipped so origin is not thrashed
+- **Conflict resolution**: markdown git conflicts are auto-resolved by keeping both sides; projection conflicts (name already a real file under `~/.claude/rules`) leave the real file untouched
+- **Scan policy**: when projection is active, the index reads harness rule dirs only (links resolve into origin) — origin `rules/` is not double-scanned
 
-### Sync repo structure
+Optional origin override: set `sync.repoDir` in `~/.claude/memex.json`, or env `MEMEX_ORIGIN`. Mass migrate to `~/.memex` is **opt-in only** — not required.
+
+### Sync / origin structure
 
 ```
-~/.local/share/memex-claude/
-├── .git/
-├── rules/                                      # synced global rules
-├── skills/                                     # synced global skills
-│   └── my-skill/SKILL.md
-└── projects/
-    ├── github.com/you/my-project/              # git-identified projects
-    │   └── memory/*.md
-    └── _local/                                 # non-git projects
-        └── -home-you-some-project/
-            └── memory/*.md
+# Effective origin (resolved; one tree — not both forever)
+~/.memex/                         # product default when present / greenfield
+# or ~/.local/share/memex-claude/  # legacy-claude corpus (still supported)
+├── .git/                         # when remote-backed
+├── rules/                        # origin rules (source of truth)
+├── skills/
+└── projects/.../memory/
+
+# Harness projection surface
+~/.claude/rules/*.md              # managed entries = symlinks → origin/rules/*
 ```
 
 ### Project identity

--- a/docs/specs/2026-07-11-g3-adapter-alignment-file-rules-projection.md
+++ b/docs/specs/2026-07-11-g3-adapter-alignment-file-rules-projection.md
@@ -1,8 +1,8 @@
 # memex-claude addendum — G3 file-rules projection (shared-origin alignment)
 
 **Date:** 2026-07-11  
-**Status:** design only — **no implementation in this PR**  
-**Authority:** operator steer `flotilla-dispatch-c29001c1` · G3 brief `adapter-alignment-g3-2026-07-11.md`  
+**Status:** design **gated** (#54) · **wave LIVE** (CoS AUTHORIZE 2026-07-11) · impl in follow-on PR  
+**Authority:** operator steer `flotilla-dispatch-c29001c1` · CoS AUTHORIZE wave · G3 brief `adapter-alignment-g3-2026-07-11.md`  
 **Pin (impl):** `@jim80net/memex-core@^0.6.0` (currently package.json pins `^0.5.0` — bump at impl)  
 **Proven path:** memex-grok#30 design + #31 impl (`src/core/projection.ts`)  
 **Core contract:** `resolveOriginRoot` / `planProjection` / `applyProjection` / `defaultOriginRoot` / `legacyClaudeOriginRoot`  
@@ -15,9 +15,24 @@
 
 Align the Claude adapter with the **same lifecycle model** Grok proved: core owns origin truth and symlink policy; this adapter owns **Claude harness paths**, **when** projection runs, **scan/index coexistence** with the existing copy-sync path, and **doctor/health messaging**.
 
-Claude already delivers rules/skills/memory via **hooks** (`UserPromptSubmit` inject) and optional git **copy-sync** (`SessionStart` pull → scan origin tree; `Stop` copy harness → origin). G3 does **not** replace hook delivery or invent inject-first. It adds **file-shaped provenance**: managed origin rules appear under `~/.claude/rules` (and optionally project rules) as **absolute symlinks into the shared origin**, fail-closed, with **one content blob → one index entry**.
+Claude already delivers rules/skills/memory via **hooks** (`UserPromptSubmit` inject) and optional git **copy-sync** (`SessionStart` pull → scan origin tree; `Stop` copy harness → origin). G3 does **not** invent inject paths. It **prefers file-shaped surface**: managed origin rules appear under `~/.claude/rules` (and optionally project rules) as **absolute symlinks into the shared origin**, fail-closed, with **one content blob → one index entry**. Hooks continue to *read* those files via the index; they are not a substitute for missing on-disk projection.
 
 **Impl gate:** this design passes memex systems-review → pin `memex-core@^0.6.0` → implement projection + scan policy + doctor skill checks → dogfood / manual verify → no freeze-SHA / self-merge from this seat.
+
+### 0.1 CoS-locked acceptance (wave tracks A/B/C)
+
+| Track | CoS requirement | Claude plan (this design) |
+|-------|-----------------|---------------------------|
+| **A. Core pin** | `@jim80net/memex-core@^0.6.0`; tests green; no silent skew | Impl step 1: bump `package.json` + lockfile from `^0.5.0` → `^0.6.0`; CI + local `pnpm test` / `typecheck` green before/with projection |
+| **B. File-shaped projection** | Rules (skills where supported) as files under harness dirs via core plan/apply; prefer files over inject; no invented inject paths | v1: project origin `rules/` → `~/.claude/rules` (verified path); skills projection **supported by harness** (`~/.claude/skills`) but **deferred** after rules (same as grok#31); hooks remain delivery, not a new inject surface |
+| **C. `~/.memex` migrate** | **Opt-in only** if it unblocks A/B; default keep current origins | **Default:** `resolveOriginRoot` chain — legacy-claude `~/.local/share/memex-claude` OK. **No mass migrate** in this wave. Optional one-pager only if A/B blocked (not expected for Claude) |
+
+### 0.2 Pin matrix row (this seat)
+
+| Seat | Pin before (main) | Target | Gap |
+|------|-------------------|--------|-----|
+| **memex-claude** | `^0.5.0` | `^0.6.0` | bump + projection (this design → impl PR after gate) |
+| memex-grok (reference) | `^0.6.0` | `^0.6.0` | **DONE** |
 
 ---
 
@@ -205,7 +220,7 @@ Core 0.6.0 resolver product default is **`~/.memex`**, with XDG + **legacy-claud
 | Config override | Prefer core-native: optional `sync` extension **or** env `MEMEX_ORIGIN`. Grok added local `repoDir?: string` on its SyncConfig bridge — Claude may mirror that **thin** optional field **or** rely on `MEMEX_ORIGIN` only in v1 to avoid schema drift. **Recommendation:** accept optional `sync.repoDir` (string) in mergeConfig as adapter-local override mapped to `resolveOriginRoot({ root })`, same as grok, until core documents a single JSON field name. |
 | Live host with both `~/.memex` and legacy corpus | Resolver returns first existing in precedence; doctor must print `source` (`default` \| `xdg` \| `legacy-claude` \| `env` \| `explicit`) so operators see which tree is active |
 
-**Non-goal this wave:** force-migrate production origin to `~/.memex` (brief: optional follow-on).
+**Track C — default keep current origins.** Do **not** mass-migrate production to `~/.memex` in this wave. Resolver already handles `legacy-claude`. A host-local opt-in migrate is allowed **only** if A/B are blocked without it (Claude: not expected — legacy path is first-class). If ever needed: PREP one-pager with reversibility before any mass move (CoS scope C).
 
 ---
 
@@ -432,17 +447,20 @@ Host-path egress: prefer relative/`~/…` in skill prose; scrub absolute host pa
 - After gate: authorize impl PR against pin `^0.6.0`.
 - Do not require freeze-SHA from this seat.
 
-### ## Backlog
+### ## Backlog (wave LIVE — CoS AUTHORIZE)
 
 | Marker | Item | Owner |
 |--------|------|-------|
-| `[blocked] settle: design-gate` | Impl blocked until this design is gated by memex. | memex |
-| `[ready] settle: core-pin` | Core 0.6.0 published; pin bump is impl-step 1. | memex-claude (post-gate) |
-| `[follow-on] settle: skills-projection` | Same symlink model for `~/.claude/skills` after rules path proven. | memex-claude |
-| `[follow-on] settle: live-rules-migration` | Optional tool to convert identical real files → managed symlinks (content-equal only). | memex-claude / memex |
-| `[follow-on] settle: origin-migrate-to-memex` | Optional host migrate legacy-claude → `~/.memex` (core-owned story). | memex-core |
+| `[live] settle: design-gate` | Design PR open; **awaiting memex gate** before impl. | memex |
+| `[live] settle: A-core-pin` | After design gate: bump `^0.5.0` → `^0.6.0`; tests green; no silent skew. | memex-claude |
+| `[live] settle: B-projection` | After design gate: projection + scan policy + Stop filter + doctor skill. | memex-claude |
+| `[ready] settle: core-published` | Core 0.6.0 already on npm (Grok reference). | — |
+| `[follow-on] settle: skills-projection` | Track B skills where supported — same symlink model for `~/.claude/skills` after rules proven. | memex-claude |
+| `[follow-on] settle: live-rules-migration` | Optional convert identical real files → managed symlinks (content-equal only). | memex-claude / memex |
+| `[opt-in] settle: C-memex-migrate` | Track C — only if A/B blocked; PREP + reversibility; default keep legacy-claude. | memex-core / operator |
 | `[non-goal] settle: inject-first` | Explicitly out of scope. | — |
 | `[non-goal] settle: refinement-product` | Deferred by operator. | — |
+| `[non-goal] settle: freeze-SHA / self-merge / codex cutover` | Not this seat. | — |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
-    "@jim80net/memex-core": "^0.5.0"
+    "@jim80net/memex-core": "^0.6.0"
   },
   "packageManager": "pnpm@9.15.0",
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^3.8.1
         version: 3.8.1
       '@jim80net/memex-core':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -200,8 +200,8 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
-  '@jim80net/memex-core@0.5.0':
-    resolution: {integrity: sha512-a8DIxsFk0WCDhZesfAQUbIgTNgfrCSzhxGSKKlC7l9paFx0gmzhmoFFJc7BYPGVfbJZRENC5Uoyp4JMgt0THZA==}
+  '@jim80net/memex-core@0.6.0':
+    resolution: {integrity: sha512-njwQ8eebMufiHhwFEbKnc+JO0ItcXgXBRIc7b/EwWUrRivdZEtIgAZxWJMd3lySWQxgB83aHwI82Jr3iw4tQcg==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -856,7 +856,7 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@jim80net/memex-core@0.5.0':
+  '@jim80net/memex-core@0.6.0':
     optionalDependencies:
       '@huggingface/transformers': 3.8.1
 

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -119,6 +119,31 @@ ls .claude/rules/*.md 2>/dev/null
 ls ~/.claude/projects/*/memory/*.md 2>/dev/null
 ```
 
+### 5b. Shared-origin / rules projection (G3)
+
+When `sync.enabled: true` in `~/.claude/memex.json`, memex projects origin rules into `~/.claude/rules` as **symlinks** (fail-closed; never overwrites real files).
+
+```bash
+# Pin (expect @jim80net/memex-core ^0.6.0)
+node -e "console.log(require('./node_modules/@jim80net/memex-core/package.json').version)" 2>/dev/null \
+  || cat node_modules/@jim80net/memex-core/package.json 2>/dev/null | head -5
+
+# Effective origin (resolver: ~/.memex → XDG → legacy-claude)
+ls -la ~/.memex/rules 2>/dev/null | head
+ls -la ~/.local/share/memex-claude/rules 2>/dev/null | head
+
+# Projection provenance — managed rules should be symlinks into origin
+ls -la ~/.claude/rules | head -20
+# Example: readlink on a projected rule (name will vary)
+# readlink -f ~/.claude/rules/some-rule.md
+
+# Real files that share a name with an origin entry are left alone (conflicts)
+find ~/.claude/rules -maxdepth 1 -type f -name '*.md' | wc -l
+find ~/.claude/rules -maxdepth 1 -type l -name '*.md' | wc -l
+```
+
+**Memory surface (Claude):** rules/skills/memories deliver via **hooks** (UserPromptSubmit) and auto-memory assist/takeover. Projection makes shared-origin files visible under `~/.claude/rules` as symlinks — it does **not** invent a new inject path.
+
 If no files are found in any location, memex has nothing to inject. Create a test skill:
 
 ```bash

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -29,10 +29,23 @@ export type SleepScheduleConfig = {
 
 export type AutoMemoryMode = "assist" | "takeover";
 
+/**
+ * Extension of SyncConfig with optional origin root override.
+ * Maps to core resolveOriginRoot({ root }) — product default ~/.memex,
+ * with legacy-claude fallback via the resolver chain.
+ */
+export type ClaudeSyncConfig = SyncConfig & {
+  /**
+   * Explicit origin root override (absolute or ~/…).
+   * When unset, core resolveOriginRoot walks ~/.memex → XDG → legacy-claude.
+   */
+  repoDir?: string;
+};
+
 export type SkillRouterConfig = MemexCoreConfig & {
   autoMemoryMode: AutoMemoryMode;
   skillDirs: string[];
-  sync: SyncConfig;
+  sync: ClaudeSyncConfig;
   sleepSchedule: SleepScheduleConfig;
   hooks: {
     UserPromptSubmit: HookConfig;
@@ -111,6 +124,12 @@ function mergeConfig(user: Partial<SkillRouterConfig>): SkillRouterConfig {
 
   if (user.sync) {
     base.sync = { ...base.sync, ...user.sync };
+    // Preserve optional repoDir only when explicitly a non-empty string
+    if (typeof user.sync.repoDir === "string" && user.sync.repoDir.trim() !== "") {
+      base.sync.repoDir = user.sync.repoDir;
+    } else if ("repoDir" in user.sync && (user.sync.repoDir === undefined || user.sync.repoDir === "")) {
+      delete base.sync.repoDir;
+    }
   }
 
   if (user.sleepSchedule) {

--- a/src/core/projection.ts
+++ b/src/core/projection.ts
@@ -1,0 +1,309 @@
+/**
+ * Claude harness projection — thin adapter over memex-core origin primitives.
+ *
+ * Design: docs/specs/2026-07-11-g3-adapter-alignment-file-rules-projection.md
+ * Proven path: memex-grok#31 src/core/projection.ts
+ * Core: resolveOriginRoot / planProjection / applyProjection (@jim80net/memex-core@0.6+)
+ *
+ * Does not invent a parallel origin layout. Prefer file-shaped rules under
+ * ~/.claude/rules; no new inject paths.
+ */
+
+import {
+  applyProjection,
+  initSyncRepo,
+  isPathInsideRoot,
+  planProjection,
+  resolveOriginRoot,
+  syncPull,
+  type ApplyProjectionResult,
+  type ProjectPlan,
+  type ProjectionTarget,
+  type ResolvedOriginRoot,
+  type SyncConfig,
+  type SyncProfile,
+} from "@jim80net/memex-core";
+import { copyFile, lstat, mkdir, readdir, readlink, rm } from "node:fs/promises";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import type { ClaudeSyncConfig, SkillRouterConfig } from "./config.ts";
+import {
+  getClaudePaths,
+  getProjectRulesDir,
+  type ClaudePaths,
+} from "./paths.ts";
+
+export type ProjectionRunOptions = {
+  config: SkillRouterConfig;
+  /** Project cwd for optional project-scoped rules projection. Default process.cwd(). */
+  cwd?: string;
+  paths?: ClaudePaths;
+  /** When true, plan only — do not apply or mkdir origin. */
+  dryRun?: boolean;
+  /** Override home for resolveOriginRoot (tests). */
+  homeDir?: string;
+  env?: NodeJS.ProcessEnv;
+  /**
+   * When true, also syncPull if repo + autoPull (SessionStart path).
+   * Default false for pure init; SessionStart passes true.
+   */
+  pull?: boolean;
+};
+
+export type ProjectionRunReport = {
+  profileSet: boolean;
+  origin: ResolvedOriginRoot | null;
+  plan: ProjectPlan | null;
+  apply: ApplyProjectionResult | null;
+  pullMessage: string | null;
+  message: string;
+};
+
+/** Profile is set when adapter sync is enabled (maps to SyncProfile.enabled). */
+export function isProjectionProfileSet(
+  config: Pick<SkillRouterConfig, "sync"> | ClaudeSyncConfig | SyncConfig,
+): boolean {
+  const sync = "sync" in config ? config.sync : config;
+  return sync.enabled === true;
+}
+
+/**
+ * Whether rules are expected to be projected into harness dirs (scan policy).
+ * When true, assembleClaudeScanDirs must not also append raw origin/rules.
+ */
+export function rulesProjectionActive(
+  config: Pick<SkillRouterConfig, "sync"> | ClaudeSyncConfig | SyncConfig,
+): boolean {
+  return isProjectionProfileSet(config);
+}
+
+/**
+ * Build harness-neutral projection targets for Claude user rules.
+ *
+ * v1: project `cwd/.claude/rules` only when callers pass an explicit
+ * `projectOriginRelDir` (e.g. `projects/<id>/rules`). Linking the same
+ * origin `rules/` into both user and project dirs would double-index.
+ * Skills projection is a follow-on (design backlog).
+ */
+export function buildClaudeProjectionTargets(
+  cwd: string,
+  paths: ClaudePaths = getClaudePaths(),
+  opts: { projectOriginRelDir?: string } = {},
+): ProjectionTarget[] {
+  const targets: ProjectionTarget[] = [
+    {
+      id: "claude-user-rules",
+      targetDir: paths.globalRulesDir,
+      originRelDir: "rules",
+      entryKind: "files",
+      pattern: "*.md",
+      initTargetDir: true,
+    },
+  ];
+  if (opts.projectOriginRelDir) {
+    targets.push({
+      id: "claude-project-rules",
+      targetDir: getProjectRulesDir(cwd),
+      originRelDir: opts.projectOriginRelDir,
+      entryKind: "files",
+      pattern: "*.md",
+      initTargetDir: true,
+    });
+  }
+  return targets;
+}
+
+/**
+ * Construct a SyncProfile from claude config (legacy SyncConfig bridge).
+ * Prefer core types only — no forked origin schema.
+ */
+export function buildClaudeSyncProfile(
+  config: SkillRouterConfig,
+  cwd: string,
+  paths: ClaudePaths = getClaudePaths(),
+): SyncProfile {
+  return {
+    version: 1,
+    enabled: config.sync.enabled,
+    origin: {
+      root: config.sync.repoDir,
+      repo: config.sync.repo || undefined,
+    },
+    projections: config.sync.enabled
+      ? buildClaudeProjectionTargets(cwd, paths)
+      : [],
+    onClobber: "fail-closed",
+    relinkManaged: true,
+    sync: {
+      autoPull: config.sync.autoPull,
+      autoCommitPush: config.sync.autoCommitPush,
+      projectMappings: config.sync.projectMappings,
+      caseSensitive: config.sync.caseSensitive,
+    },
+  };
+}
+
+/** Map adapter sync config to core SyncConfig for initSyncRepo / syncPull. */
+export function toCoreSyncConfig(config: SkillRouterConfig | ClaudeSyncConfig): SyncConfig {
+  const sync = "sync" in config && config.sync ? config.sync : (config as ClaudeSyncConfig);
+  return {
+    enabled: sync.enabled,
+    repo: sync.repo,
+    autoPull: sync.autoPull,
+    autoCommitPush: sync.autoCommitPush,
+    projectMappings: sync.projectMappings,
+    caseSensitive: sync.caseSensitive,
+  };
+}
+
+/**
+ * Resolve live origin root via core resolver (product default ~/.memex).
+ * Explicit config.sync.repoDir maps to profile origin.root.
+ */
+export async function resolveClaudeOrigin(
+  config: SkillRouterConfig | ClaudeSyncConfig,
+  opts: { homeDir?: string; env?: NodeJS.ProcessEnv } = {},
+): Promise<ResolvedOriginRoot> {
+  const sync = "sync" in config && config.sync ? config.sync : (config as ClaudeSyncConfig);
+  return resolveOriginRoot({
+    root: sync.repoDir,
+    homeDir: opts.homeDir,
+    env: opts.env,
+  });
+}
+
+/**
+ * Ensure origin exists, optionally pull remote, plan + apply rules projection.
+ */
+export async function runClaudeProjection(
+  opts: ProjectionRunOptions,
+): Promise<ProjectionRunReport> {
+  const { config } = opts;
+  const cwd = opts.cwd ?? process.cwd();
+  const paths = opts.paths ?? getClaudePaths();
+  const dryRun = opts.dryRun === true;
+  const doPull = opts.pull === true;
+
+  if (!isProjectionProfileSet(config)) {
+    return {
+      profileSet: false,
+      origin: null,
+      plan: null,
+      apply: null,
+      pullMessage: null,
+      message:
+        "sync profile not set (sync.enabled=false); enable in memex.json to project rules",
+    };
+  }
+
+  const origin = await resolveClaudeOrigin(config, {
+    homeDir: opts.homeDir,
+    env: opts.env,
+  });
+  const coreSync = toCoreSyncConfig(config);
+
+  if (!dryRun) {
+    await mkdir(origin.root, { recursive: true });
+    await mkdir(join(origin.root, "rules"), { recursive: true });
+    if (coreSync.repo) {
+      await initSyncRepo(coreSync, origin.root);
+    }
+  }
+
+  let pullMessage: string | null = null;
+  if (!dryRun && doPull && coreSync.repo && coreSync.autoPull) {
+    pullMessage = await syncPull(coreSync, origin.root);
+  }
+
+  const targets = buildClaudeProjectionTargets(cwd, paths);
+  const plan = await planProjection(origin.root, targets, { relinkManaged: true });
+
+  if (dryRun) {
+    return {
+      profileSet: true,
+      origin,
+      plan,
+      apply: null,
+      pullMessage,
+      message: `dry-run: origin=${origin.root} source=${origin.source} links=${plan.links.length} conflicts=${plan.conflicts.length}`,
+    };
+  }
+
+  const apply = await applyProjection(plan, { onClobber: "fail-closed" });
+  return {
+    profileSet: true,
+    origin,
+    plan,
+    apply,
+    pullMessage,
+    message: `origin=${origin.root} source=${origin.source} linked=${apply.linked} skipped=${apply.skipped} conflicts=${apply.conflicts.length}`,
+  };
+}
+
+/**
+ * True when path is a symlink whose target resolves under originRoot
+ * (managed projection link — do not copy-up on Stop).
+ */
+export async function isManagedOriginSymlink(
+  path: string,
+  originRoot: string,
+): Promise<boolean> {
+  try {
+    const st = await lstat(path);
+    if (!st.isSymbolicLink()) return false;
+    const target = await readlink(path);
+    const abs = isAbsolute(target) ? resolve(target) : resolve(dirname(path), target);
+    return isPathInsideRoot(originRoot, abs);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Stage only non-managed harness rule entries for Stop copy-up.
+ * Managed origin symlinks are skipped so syncCommitAndPush does not thrash origin.
+ * Returns null when staging is unnecessary (caller should use rulesDir as-is).
+ */
+export async function stageRulesForCopyUp(
+  rulesDir: string,
+  originRoot: string,
+  stageDir: string,
+): Promise<{ staged: number; skippedManaged: number }> {
+  await mkdir(stageDir, { recursive: true });
+  let entries: string[];
+  try {
+    entries = await readdir(rulesDir);
+  } catch {
+    return { staged: 0, skippedManaged: 0 };
+  }
+
+  let staged = 0;
+  let skippedManaged = 0;
+
+  for (const entry of entries) {
+    if (!entry.endsWith(".md")) continue;
+    const src = join(rulesDir, entry);
+    if (await isManagedOriginSymlink(src, originRoot)) {
+      skippedManaged++;
+      continue;
+    }
+    try {
+      const st = await lstat(src);
+      if (!st.isFile() && !st.isSymbolicLink()) continue;
+      await copyFile(src, join(stageDir, entry));
+      staged++;
+    } catch {
+      // skip unreadable
+    }
+  }
+
+  return { staged, skippedManaged };
+}
+
+/** Remove a staging directory created for Stop copy-up (best-effort). */
+export async function cleanupStageDir(stageDir: string): Promise<void> {
+  try {
+    await rm(stageDir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+}

--- a/src/core/scan-roots.ts
+++ b/src/core/scan-roots.ts
@@ -1,4 +1,3 @@
-import { join } from "node:path";
 import {
   buildScanRoots,
   findMatchingProjectMemoryDirs,
@@ -11,6 +10,15 @@ import {
   getProjectRulesDir,
   getProjectSkillsDir,
 } from "./paths.ts";
+import { rulesProjectionActive } from "./projection.ts";
+
+export type AssembleClaudeScanDirsOptions = {
+  /**
+   * Resolved shared origin root (from resolveOriginRoot / resolveClaudeOrigin).
+   * When omitted and sync is enabled, falls back to paths.syncRepoDir (legacy).
+   */
+  originRoot?: string;
+};
 
 /** Assemble scan directories — mirrors src/main.ts wiring. */
 export async function assembleClaudeScanDirs(
@@ -18,6 +26,7 @@ export async function assembleClaudeScanDirs(
   paths: Pick<ClaudePaths, "globalSkillsDir" | "globalRulesDir" | "projectsDir" | "syncRepoDir">,
   extraSkillDirs: string[],
   syncConfig: SyncConfig,
+  opts: AssembleClaudeScanDirsOptions = {},
 ): Promise<ScanDirs> {
   const scanDirs: ScanDirs = {
     skillDirs: [paths.globalSkillsDir, getProjectSkillsDir(cwd), ...extraSkillDirs],
@@ -26,13 +35,19 @@ export async function assembleClaudeScanDirs(
   };
 
   if (syncConfig.enabled) {
-    const syncDirs = getSyncScanDirs(paths.syncRepoDir);
+    const repoDir = opts.originRoot ?? paths.syncRepoDir;
+    const syncDirs = getSyncScanDirs(repoDir);
     scanDirs.skillDirs.push(syncDirs.skillsDir);
-    scanDirs.ruleDirs.push(syncDirs.rulesDir);
+
+    // When rules projection is active, harness rule dirs hold symlinks into
+    // origin — do not also append raw origin/rules (one blob → one index entry).
+    if (!rulesProjectionActive(syncConfig)) {
+      scanDirs.ruleDirs.push(syncDirs.rulesDir);
+    }
 
     const syncMemDirs = await findMatchingProjectMemoryDirs(
       cwd,
-      paths.syncRepoDir,
+      repoDir,
       syncConfig,
     );
     scanDirs.memoryDirs.push(...syncMemDirs);

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -6,10 +6,21 @@ import { promisify } from "node:util";
 import { randomBytes } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { syncPull, loadRegistry, saveRegistry, registerProject, withFileLock } from "@jim80net/memex-core";
-import type { HookInput, HookOutput, SyncConfig } from "@jim80net/memex-core";
-import type { SleepScheduleConfig, AutoMemoryMode } from "../core/config.ts";
+import type { HookInput, HookOutput } from "@jim80net/memex-core";
+import type {
+  ClaudeSyncConfig,
+  SleepScheduleConfig,
+  AutoMemoryMode,
+  SkillRouterConfig,
+} from "../core/config.ts";
 import { isAutoMemoryEnabled } from "../core/config.ts";
 import { getClaudePaths } from "../core/paths.ts";
+import {
+  isProjectionProfileSet,
+  resolveClaudeOrigin,
+  runClaudeProjection,
+  toCoreSyncConfig,
+} from "../core/projection.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -29,9 +40,11 @@ function getPluginRoot(): string {
 
 export async function handleSessionStart(
   input: HookInput,
-  syncConfig: SyncConfig,
+  syncConfig: ClaudeSyncConfig,
   sleepConfig: SleepScheduleConfig,
-  autoMemoryMode: AutoMemoryMode
+  autoMemoryMode: AutoMemoryMode,
+  /** Full router config when available — enables G3 projection after pull. */
+  routerConfig?: SkillRouterConfig,
 ): Promise<HookOutput> {
   const cwd = input.cwd || process.cwd();
   const paths = getClaudePaths();
@@ -48,10 +61,36 @@ export async function handleSessionStart(
     // Best-effort
   }
 
-  // 2. Sync pull
-  if (syncConfig.enabled && syncConfig.autoPull) {
+  // 2. Sync pull + rules projection (G3)
+  //    When full config is available and profile is set: resolveOriginRoot →
+  //    pull into origin → plan/apply symlinks (fail-closed, no clobber).
+  //    Else legacy: pull into paths.syncRepoDir only.
+  if (routerConfig && isProjectionProfileSet(routerConfig)) {
     try {
-      const result = await syncPull(syncConfig, paths.syncRepoDir);
+      const report = await runClaudeProjection({
+        config: routerConfig,
+        cwd,
+        paths,
+        pull: true,
+      });
+      if (report.pullMessage) {
+        process.stderr.write(`memex[sync]: ${report.pullMessage}\n`);
+      }
+      process.stderr.write(`memex[projection]: ${report.message}\n`);
+    } catch (err) {
+      process.stderr.write(`memex[projection]: failed: ${err}\n`);
+    }
+  } else if (syncConfig.enabled && syncConfig.autoPull) {
+    try {
+      const coreSync = toCoreSyncConfig({ sync: syncConfig } as SkillRouterConfig);
+      let repoDir = paths.syncRepoDir;
+      try {
+        const origin = await resolveClaudeOrigin(syncConfig);
+        if (origin.exists) repoDir = origin.root;
+      } catch {
+        // keep legacy syncRepoDir
+      }
+      const result = await syncPull(coreSync, repoDir);
       process.stderr.write(`memex[sync]: ${result}\n`);
     } catch (err) {
       process.stderr.write(`memex[sync]: pull failed: ${err}\n`);

--- a/src/hooks/stop.ts
+++ b/src/hooks/stop.ts
@@ -1,16 +1,25 @@
 import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import type { SkillIndex } from "@jim80net/memex-core";
-import type { HookInput, SyncConfig } from "@jim80net/memex-core";
+import type { HookInput } from "@jim80net/memex-core";
 import { syncCommitAndPush } from "@jim80net/memex-core";
-import type { StopHookConfig } from "../core/config.ts";
+import type { ClaudeSyncConfig, SkillRouterConfig, StopHookConfig } from "../core/config.ts";
 import { getClaudePaths, getProjectMemoryDir } from "../core/paths.ts";
+import {
+  cleanupStageDir,
+  resolveClaudeOrigin,
+  rulesProjectionActive,
+  stageRulesForCopyUp,
+  toCoreSyncConfig,
+} from "../core/projection.ts";
 
 
 export async function handleStop(
   input: HookInput,
   index: SkillIndex,
   hookConfig: StopHookConfig,
-  syncConfig?: SyncConfig
+  syncConfig?: ClaudeSyncConfig,
+  routerConfig?: SkillRouterConfig,
 ): Promise<void> {
   // --- Behavioral rules ---
   let behavioralRuleFeedback: string | null = null;
@@ -57,12 +66,51 @@ export async function handleStop(
   if (syncConfig?.enabled && syncConfig.autoCommitPush) {
     const cwd = input.cwd || process.cwd();
     const paths = getClaudePaths();
+    const coreSync = toCoreSyncConfig(
+      routerConfig ?? ({ sync: syncConfig } as SkillRouterConfig),
+    );
+
+    let originRoot = paths.syncRepoDir;
+    try {
+      const origin = await resolveClaudeOrigin(
+        routerConfig ?? ({ sync: syncConfig } as SkillRouterConfig),
+      );
+      originRoot = origin.root;
+    } catch {
+      // keep legacy syncRepoDir
+    }
+
+    // When rules projection is active, stage only non-managed (real) rule files
+    // so managed origin symlinks are not copy-up thrash (design §7.2A).
+    let rulesSource = paths.globalRulesDir;
+    let stageDir: string | null = null;
+    if (rulesProjectionActive(syncConfig)) {
+      stageDir = join(paths.cacheDir, `stop-rules-stage-${process.pid}`);
+      try {
+        const { staged, skippedManaged } = await stageRulesForCopyUp(
+          paths.globalRulesDir,
+          originRoot,
+          stageDir,
+        );
+        rulesSource = stageDir;
+        if (skippedManaged > 0) {
+          process.stderr.write(
+            `memex[sync]: skipped ${skippedManaged} managed rule symlink(s); staging ${staged} local rule(s)\n`,
+          );
+        }
+      } catch (err) {
+        process.stderr.write(`memex[sync]: rules stage failed, using harness dir: ${err}\n`);
+        stageDir = null;
+        rulesSource = paths.globalRulesDir;
+      }
+    }
+
     try {
       const result = await syncCommitAndPush(
-        syncConfig,
-        paths.syncRepoDir,
+        coreSync,
+        originRoot,
         {
-          rules: paths.globalRulesDir,
+          rules: rulesSource,
           skills: paths.globalSkillsDir,
           projectMemoryDir: getProjectMemoryDir(cwd, paths.projectsDir),
         },
@@ -71,6 +119,8 @@ export async function handleStop(
       process.stderr.write(`memex[sync]: ${result}\n`);
     } catch (err) {
       process.stderr.write(`memex[sync]: commit+push failed: ${err}\n`);
+    } finally {
+      if (stageDir) await cleanupStageDir(stageDir);
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import type { HookInput, HookOutput } from "@jim80net/memex-core";
 import { loadConfig } from "./core/config.ts";
 import { getClaudePaths } from "./core/paths.ts";
 import { assembleClaudeScanDirs, buildClaudeScanRoots } from "./core/scan-roots.ts";
+import { resolveClaudeOrigin } from "./core/projection.ts";
 import { handleUserPrompt } from "./hooks/user-prompt.ts";
 import { handleStop } from "./hooks/stop.ts";
 import { handlePreToolUse } from "./hooks/pre-tool-use.ts";
@@ -38,6 +39,35 @@ async function main(): Promise<void> {
 
   const cwd = input.cwd || process.cwd();
   const paths = getClaudePaths();
+  const event = input.hook_event_name;
+
+  // SessionStart: pull + project before any index work (design §8).
+  // SessionStart does not use the skill index.
+  if (event === "SessionStart") {
+    let result: HookOutput = {};
+    try {
+      result = await handleSessionStart(
+        input,
+        config.sync,
+        config.sleepSchedule,
+        config.autoMemoryMode,
+        config,
+      );
+    } catch (err) {
+      process.stderr.write(`memex: handler error for SessionStart: ${err}\n`);
+    }
+    outputResult(result);
+    return;
+  }
+
+  // Resolve origin for scan policy (avoid hardcoding only legacy syncRepoDir)
+  let originRoot: string | undefined;
+  try {
+    const origin = await resolveClaudeOrigin(config);
+    originRoot = origin.root;
+  } catch {
+    originRoot = undefined;
+  }
 
   // Construct core objects
   const provider = new LocalEmbeddingProvider(config.embeddingModel, paths.modelsDir);
@@ -48,6 +78,7 @@ async function main(): Promise<void> {
     paths,
     config.skillDirs,
     config.sync,
+    { originRoot },
   );
   const registry = buildClaudeScanRoots(cwd, paths, scanDirs, config.sync.enabled);
   const index = new SkillIndex(config, provider, cachePath, { registry });
@@ -61,15 +92,10 @@ async function main(): Promise<void> {
     return;
   }
 
-  const event = input.hook_event_name;
   let result: HookOutput = {};
 
   try {
     switch (event) {
-      case "SessionStart":
-        result = await handleSessionStart(input, config.sync, config.sleepSchedule, config.autoMemoryMode);
-        break;
-
       case "UserPromptSubmit":
         if (config.hooks.UserPromptSubmit.enabled) {
           result = await handleUserPrompt(
@@ -90,7 +116,7 @@ async function main(): Promise<void> {
 
       case "Stop":
         if (config.hooks.Stop.enabled) {
-          await handleStop(input, index, config.hooks.Stop, config.sync);
+          await handleStop(input, index, config.hooks.Stop, config.sync, config);
         }
         break;
 

--- a/test/cross-adapter-pin-alignment.test.ts
+++ b/test/cross-adapter-pin-alignment.test.ts
@@ -4,8 +4,8 @@ import { describe, expect, it } from "vitest";
 
 const CROSS_ADAPTER_TRANSFORMERS_RANGE = "^3.8.1";
 const CROSS_ADAPTER_TRANSFORMERS_RESOLVED = "3.8.1";
-const CROSS_ADAPTER_MEMEX_CORE_RANGE = "^0.5.0";
-const CROSS_ADAPTER_MEMEX_CORE_RESOLVED = "0.5.0";
+const CROSS_ADAPTER_MEMEX_CORE_RANGE = "^0.6.0";
+const CROSS_ADAPTER_MEMEX_CORE_RESOLVED = "0.6.0";
 
 function readJson(relFromRepoRoot: string): Record<string, unknown> {
   const url = new URL(`../${relFromRepoRoot}`, import.meta.url);

--- a/test/projection.test.ts
+++ b/test/projection.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { lstat, mkdir, readlink, rm, writeFile, symlink } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { DEFAULT_CONFIG } from "../src/core/config.ts";
+import type { ClaudePaths } from "../src/core/paths.ts";
+import {
+  buildClaudeProjectionTargets,
+  isManagedOriginSymlink,
+  isProjectionProfileSet,
+  runClaudeProjection,
+  stageRulesForCopyUp,
+} from "../src/core/projection.ts";
+import { assembleClaudeScanDirs } from "../src/core/scan-roots.ts";
+
+function fakePaths(root: string): ClaudePaths {
+  const cacheDir = join(root, ".claude", "cache");
+  return {
+    cacheDir,
+    modelsDir: join(cacheDir, "models"),
+    sessionsDir: join(cacheDir, "sessions"),
+    syncRepoDir: join(root, "origin"),
+    projectsDir: join(root, ".claude", "projects"),
+    telemetryPath: join(cacheDir, "memex-telemetry.json"),
+    registryPath: join(cacheDir, "memex-projects.json"),
+    tracesDir: join(cacheDir, "memex-traces"),
+    configPath: join(root, ".claude", "memex.json"),
+    preCompactDir: join(cacheDir, "pre-compact"),
+    cronWatermarkPath: join(cacheDir, "memex-cron-watermark"),
+    autoMemoryWatermarkPath: join(cacheDir, "memex-automemory-warned"),
+    globalSkillsDir: join(root, ".claude", "skills"),
+    globalRulesDir: join(root, ".claude", "rules"),
+  };
+}
+
+describe("projection profile gate", () => {
+  it("is off when sync.enabled is false (default)", () => {
+    expect(isProjectionProfileSet(DEFAULT_CONFIG)).toBe(false);
+  });
+
+  it("is on when sync.enabled is true", () => {
+    expect(
+      isProjectionProfileSet({
+        ...DEFAULT_CONFIG,
+        sync: { ...DEFAULT_CONFIG.sync, enabled: true },
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("buildClaudeProjectionTargets", () => {
+  it("projects user rules only by default (no double-index of origin rules)", () => {
+    const root = "/tmp/claude-proj-paths";
+    const paths = fakePaths(root);
+    const targets = buildClaudeProjectionTargets("/work/repo", paths);
+    expect(targets).toHaveLength(1);
+    expect(targets[0]!.id).toBe("claude-user-rules");
+    expect(targets[0]!.targetDir).toBe(join(root, ".claude", "rules"));
+    expect(targets[0]!.originRelDir).toBe("rules");
+    expect(targets[0]!.entryKind).toBe("files");
+  });
+
+  it("adds project rules only when projectOriginRelDir is explicit", () => {
+    const paths = fakePaths("/tmp/p");
+    const targets = buildClaudeProjectionTargets("/work/repo", paths, {
+      projectOriginRelDir: "projects/foo/rules",
+    });
+    expect(targets.map((t) => t.id)).toEqual([
+      "claude-user-rules",
+      "claude-project-rules",
+    ]);
+    expect(targets[1]!.originRelDir).toBe("projects/foo/rules");
+    expect(targets[1]!.targetDir).toBe(join("/work/repo", ".claude", "rules"));
+  });
+});
+
+describe("runClaudeProjection", () => {
+  let root: string;
+  let paths: ClaudePaths;
+
+  beforeEach(async () => {
+    root = join(tmpdir(), `mc-proj-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    await mkdir(root, { recursive: true });
+    paths = fakePaths(root);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("no-ops with clear message when profile not set", async () => {
+    const report = await runClaudeProjection({
+      config: DEFAULT_CONFIG,
+      paths,
+      cwd: root,
+      homeDir: root,
+    });
+    expect(report.profileSet).toBe(false);
+    expect(report.apply).toBeNull();
+    expect(report.message).toMatch(/sync\.enabled=false/);
+  });
+
+  it("creates absolute symlinks from origin rules into ~/.claude/rules", async () => {
+    const origin = paths.syncRepoDir;
+    await mkdir(join(origin, "rules"), { recursive: true });
+    await writeFile(join(origin, "rules", "dogfood.md"), "# dogfood\n", "utf8");
+
+    const report = await runClaudeProjection({
+      config: {
+        ...DEFAULT_CONFIG,
+        sync: {
+          ...DEFAULT_CONFIG.sync,
+          enabled: true,
+          repoDir: origin,
+          autoPull: false,
+        },
+      },
+      paths,
+      cwd: root,
+      homeDir: root,
+    });
+
+    expect(report.profileSet).toBe(true);
+    expect(report.apply?.linked).toBe(1);
+    expect(report.apply?.conflicts).toEqual([]);
+
+    const linkPath = join(paths.globalRulesDir, "dogfood.md");
+    const st = await lstat(linkPath);
+    expect(st.isSymbolicLink()).toBe(true);
+    const target = await readlink(linkPath);
+    expect(target).toBe(join(origin, "rules", "dogfood.md"));
+  });
+
+  it("does not clobber a real file (conflict, partial apply)", async () => {
+    const origin = paths.syncRepoDir;
+    await mkdir(join(origin, "rules"), { recursive: true });
+    await writeFile(join(origin, "rules", "a.md"), "origin-a\n", "utf8");
+    await writeFile(join(origin, "rules", "b.md"), "origin-b\n", "utf8");
+    await mkdir(paths.globalRulesDir, { recursive: true });
+    await writeFile(join(paths.globalRulesDir, "a.md"), "local-real\n", "utf8");
+
+    const report = await runClaudeProjection({
+      config: {
+        ...DEFAULT_CONFIG,
+        sync: {
+          ...DEFAULT_CONFIG.sync,
+          enabled: true,
+          repoDir: origin,
+          autoPull: false,
+        },
+      },
+      paths,
+      cwd: root,
+      homeDir: root,
+    });
+
+    expect(report.apply?.conflicts.some((c) => c.reason === "real-file")).toBe(true);
+    const b = join(paths.globalRulesDir, "b.md");
+    expect((await lstat(b)).isSymbolicLink()).toBe(true);
+    expect((await lstat(join(paths.globalRulesDir, "a.md"))).isSymbolicLink()).toBe(false);
+  });
+
+  it("dry-run does not create links", async () => {
+    const origin = paths.syncRepoDir;
+    await mkdir(join(origin, "rules"), { recursive: true });
+    await writeFile(join(origin, "rules", "x.md"), "x\n", "utf8");
+
+    const report = await runClaudeProjection({
+      config: {
+        ...DEFAULT_CONFIG,
+        sync: { ...DEFAULT_CONFIG.sync, enabled: true, repoDir: origin, autoPull: false },
+      },
+      paths,
+      cwd: root,
+      homeDir: root,
+      dryRun: true,
+    });
+
+    expect(report.plan?.links.length).toBeGreaterThan(0);
+    expect(report.apply).toBeNull();
+    await expect(lstat(join(paths.globalRulesDir, "x.md"))).rejects.toThrow();
+  });
+});
+
+describe("assembleClaudeScanDirs projection policy", () => {
+  it("does not append origin/rules when projection is active", async () => {
+    const root = join(tmpdir(), `mc-scan-${Date.now()}`);
+    const paths = fakePaths(root);
+    const origin = join(root, "origin");
+    const scanDirs = await assembleClaudeScanDirs(
+      join(root, "proj"),
+      paths,
+      [],
+      { enabled: true, repo: "", autoPull: false, autoCommitPush: false, projectMappings: {} },
+      { originRoot: origin },
+    );
+    expect(scanDirs.ruleDirs).toContain(paths.globalRulesDir);
+    expect(scanDirs.ruleDirs).not.toContain(join(origin, "rules"));
+    // skills still scan origin
+    expect(scanDirs.skillDirs).toContain(join(origin, "skills"));
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("appends origin/rules when sync enabled but projection inactive", async () => {
+    // projection active === sync.enabled; when disabled, no origin append either
+    const root = join(tmpdir(), `mc-scan2-${Date.now()}`);
+    const paths = fakePaths(root);
+    const origin = join(root, "origin");
+    const scanDirs = await assembleClaudeScanDirs(
+      join(root, "proj"),
+      paths,
+      [],
+      { enabled: false, repo: "", autoPull: false, autoCommitPush: false, projectMappings: {} },
+      { originRoot: origin },
+    );
+    expect(scanDirs.ruleDirs).not.toContain(join(origin, "rules"));
+    await rm(root, { recursive: true, force: true });
+  });
+});
+
+describe("stageRulesForCopyUp", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = join(tmpdir(), `mc-stage-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    await mkdir(root, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("skips managed origin symlinks and stages real files", async () => {
+    const origin = join(root, "origin");
+    const rulesDir = join(root, "rules");
+    const stage = join(root, "stage");
+    await mkdir(join(origin, "rules"), { recursive: true });
+    await mkdir(rulesDir, { recursive: true });
+    await writeFile(join(origin, "rules", "managed.md"), "from-origin\n", "utf8");
+    await symlink(join(origin, "rules", "managed.md"), join(rulesDir, "managed.md"));
+    await writeFile(join(rulesDir, "local.md"), "local-only\n", "utf8");
+
+    expect(await isManagedOriginSymlink(join(rulesDir, "managed.md"), origin)).toBe(true);
+
+    const result = await stageRulesForCopyUp(rulesDir, origin, stage);
+    expect(result.skippedManaged).toBe(1);
+    expect(result.staged).toBe(1);
+    expect((await lstat(join(stage, "local.md"))).isFile()).toBe(true);
+    await expect(lstat(join(stage, "managed.md"))).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Implements **G3 adapter alignment** for memex-claude after design **#54** gated/merged. CoS AUTHORIZE tracks **A + B** (C migrate remains opt-in / not required).

| Track | What landed |
|-------|-------------|
| **A. Core pin** | `@jim80net/memex-core` `^0.5.0` → **`^0.6.0`**; pin-alignment tests updated; 56/56 green |
| **B. File-shaped projection** | Core `resolveOriginRoot` → `planProjection` / `applyProjection` into **`~/.claude/rules`** (verified `paths.ts`); absolute symlinks; fail-closed no-clobber |
| **C. `~/.memex` migrate** | **Not done** (opt-in only). Resolver keeps legacy-claude working |

### Behavior
- **SessionStart**: pull + project early (no index build needed for this event)
- **Scan**: when projection active, do **not** double-scan `origin/rules` (harness links only)
- **Stop**: stage only non-managed (real) rule files for copy-up — skip managed origin symlinks
- **Doctor skill**: shared-origin / projection / pin checks; Claude memory surface = hooks (not Grok MCP wording)
- Optional `sync.repoDir` override (same bridge as grok)

### Non-goals (held)
inject-first · skills projection (follow-on) · mass `~/.memex` migrate · freeze-SHA · self-merge · codex cutover

## Design
- Gated: https://github.com/jim80net/memex-claude/pull/54
- Spec: `docs/specs/2026-07-11-g3-adapter-alignment-file-rules-projection.md`
- Template: memex-grok#30 + #31

## Test plan
- [x] `pnpm test` — 56/56
- [x] `pnpm tsc --noEmit`
- [x] Unit: symlink create / real-file conflict / dry-run / profile-off / scan no-double / Stop stage filter
- [ ] memex gate (author ≠ merger)
- [ ] Optional dogfood: unique origin-only rule name → SessionStart → `readlink` → origin; existing real files untouched

## Merge note
Author ≠ merger. Surface to **memex** for gate/merge. Do not self-merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds G3 shared-origin rules projection using `@jim80net/memex-core@^0.6.0`, linking origin rules into `~/.claude/rules` as absolute symlinks. Updates SessionStart, scan, and Stop flows to avoid duplicate indexing and protect local files.

- **New Features**
  - Projects origin `rules/` to `~/.claude/rules` as absolute symlinks (fail-closed; never overwrites real files). Legacy corpus remains supported; optional `sync.repoDir` override.
  - SessionStart: resolve origin, pull if configured, then project (runs before building the index).
  - Scan: when projection is active, do not also scan `origin/rules` (index harness dir only; one blob → one entry).
  - Stop: stages only non-managed (real) rule files; skips managed origin symlinks to avoid copy-up thrash.
  - Adds doctor checks and updated docs; new tests cover symlink, conflicts, scan policy, and staging.

- **Dependencies**
  - Bumps `@jim80net/memex-core` to `^0.6.0` to use `resolveOriginRoot`/`planProjection`/`applyProjection`.

<sup>Written for commit 1f360a6aa5d8cd3e8907b4f494cb9c4dc5fbf4f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jim80net/memex-claude/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

