### PR TITLE
chore: resolve memex-core 0.6.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 3.8.1
       '@jim80net/memex-core':
         specifier: ^0.6.0
-        version: 0.6.0
+        version: 0.6.1
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -200,8 +200,8 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
-  '@jim80net/memex-core@0.6.0':
-    resolution: {integrity: sha512-njwQ8eebMufiHhwFEbKnc+JO0ItcXgXBRIc7b/EwWUrRivdZEtIgAZxWJMd3lySWQxgB83aHwI82Jr3iw4tQcg==}
+  '@jim80net/memex-core@0.6.1':
+    resolution: {integrity: sha512-LL+i6I+EjB1u1LaYdTR+yUZ1r6nDggNesyaqB+nnnZIOKpiB+nBpy1WaxPNNp+TobgiOTQEzj1FSwr+ttZGDCw==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -856,7 +856,7 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@jim80net/memex-core@0.6.0':
+  '@jim80net/memex-core@0.6.1':
     optionalDependencies:
       '@huggingface/transformers': 3.8.1
 

--- a/test/cross-adapter-pin-alignment.test.ts
+++ b/test/cross-adapter-pin-alignment.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 const CROSS_ADAPTER_TRANSFORMERS_RANGE = "^3.8.1";
 const CROSS_ADAPTER_TRANSFORMERS_RESOLVED = "3.8.1";
 const CROSS_ADAPTER_MEMEX_CORE_RANGE = "^0.6.0";
-const CROSS_ADAPTER_MEMEX_CORE_RESOLVED = "0.6.0";
+const CROSS_ADAPTER_MEMEX_CORE_RESOLVED = "0.6.1";
 
 function readJson(relFromRepoRoot: string): Record<string, unknown> {
   const url = new URL(`../${relFromRepoRoot}`, import.meta.url);


### PR DESCRIPTION
Preserves the compatible ^0.6.0 declaration while resolving the lockfile and alignment guard to the independently published memex-core 0.6.1 artifact. Verification: typecheck green; 59 tests passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve `@jim80net/memex-core` to 0.6.1 in the lockfile while keeping the specifier at `^0.6.0`. Update the cross-adapter alignment test to expect 0.6.1 and keep `@huggingface/transformers` at 3.8.1.

<sup>Written for commit 172f64c5eeb60ef76a3f10a12f5bb9f11cabd049. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jim80net/memex-claude/pull/59?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

