### PR TITLE
chore: reconcile memex-core 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
-    "@jim80net/memex-core": "^0.6.0"
+    "@jim80net/memex-core": "^0.7.0"
   },
   "packageManager": "pnpm@9.15.0",
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^3.8.1
         version: 3.8.1
       '@jim80net/memex-core':
-        specifier: ^0.6.0
-        version: 0.6.1
+        specifier: ^0.7.0
+        version: 0.7.0
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -200,8 +200,9 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
-  '@jim80net/memex-core@0.6.1':
-    resolution: {integrity: sha512-LL+i6I+EjB1u1LaYdTR+yUZ1r6nDggNesyaqB+nnnZIOKpiB+nBpy1WaxPNNp+TobgiOTQEzj1FSwr+ttZGDCw==}
+  '@jim80net/memex-core@0.7.0':
+    resolution: {integrity: sha512-qbEcRMSwPfz78rcrHns0Jaa2eBXEkVMqdzstW+cH/cmkuom/Ks6yaE6K06XYXtS40QSkFiOOEK4YPAWfJUkLJw==}
+    hasBin: true
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -856,7 +857,7 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@jim80net/memex-core@0.6.1':
+  '@jim80net/memex-core@0.7.0':
     optionalDependencies:
       '@huggingface/transformers': 3.8.1
 

--- a/test/cross-adapter-pin-alignment.test.ts
+++ b/test/cross-adapter-pin-alignment.test.ts
@@ -4,8 +4,8 @@ import { describe, expect, it } from "vitest";
 
 const CROSS_ADAPTER_TRANSFORMERS_RANGE = "^3.8.1";
 const CROSS_ADAPTER_TRANSFORMERS_RESOLVED = "3.8.1";
-const CROSS_ADAPTER_MEMEX_CORE_RANGE = "^0.6.0";
-const CROSS_ADAPTER_MEMEX_CORE_RESOLVED = "0.6.1";
+const CROSS_ADAPTER_MEMEX_CORE_RANGE = "^0.7.0";
+const CROSS_ADAPTER_MEMEX_CORE_RESOLVED = "0.7.0";
 
 function readJson(relFromRepoRoot: string): Record<string, unknown> {
   const url = new URL(`../${relFromRepoRoot}`, import.meta.url);


### PR DESCRIPTION
## Summary

- declare `@jim80net/memex-core@^0.7.0`
- lock and install exact npm 0.7.0 with published integrity
- advance the load-bearing cross-adapter pin guard to `^0.7.0` / `0.7.0`

## Validation

- 59/59 tests
- typecheck pass
- production build pass

Independent owner gate required; do not self-merge.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `@jim80net/memex-core` to 0.7.0 and align the cross-adapter pin guard to match. Lockfile now pins the exact 0.7.0 for consistent builds.

- **Dependencies**
  - Set `@jim80net/memex-core` to `^0.7.0` in package.json.
  - pnpm lock now resolves to `0.7.0` with published integrity.
  - Update cross-adapter pin alignment test to `^0.7.0` / `0.7.0`.

<sup>Written for commit a457b42644eb101fef5fd8cdd1a4ecc169a34f6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jim80net/memex-claude/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

