### PR TITLE
chore: adopt Core 0.7.2 bundled runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Audit production dependencies
+        run: pnpm audit --prod --audit-level low
+
       - name: Type check
         run: pnpm tsc --noEmit
 

--- a/build.ts
+++ b/build.ts
@@ -3,18 +3,29 @@
  * Build script for memex-claude standalone binaries.
  *
  * Compiles the TypeScript source into a self-contained executable using
- * `bun build --compile`. Sharp is stubbed out (we only use text embeddings).
- * The ONNX runtime shared library is copied alongside the binary.
+ * `bun build --compile`. The exact application-owned Sharp version is injected
+ * for Core's pre-import guard. The ONNX runtime shared library is copied
+ * alongside the binary.
  *
  * Usage:
  *   bun run build.ts                    # build for current platform
  *   bun run build.ts --target bun-linux-x64   # cross-compile
  */
 
-import { mkdirSync, cpSync, rmSync, symlinkSync, readlinkSync, existsSync, readdirSync, readFileSync } from "node:fs";
+import {
+  mkdirSync,
+  cpSync,
+  rmSync,
+  symlinkSync,
+  readlinkSync,
+  existsSync,
+  readdirSync,
+  readFileSync,
+} from "node:fs";
 import { join, dirname } from "node:path";
 import { execSync } from "node:child_process";
 import { platform, arch } from "node:os";
+import { createRequire } from "node:module";
 
 /** Resolve the ONNX runtime base path dynamically from node_modules. */
 function resolveOnnxBase(): string {
@@ -32,7 +43,24 @@ function resolveOnnxBase(): string {
 }
 
 const ONNX_BASE = resolveOnnxBase();
-const SHARP_SYMLINK = "node_modules/.pnpm/@huggingface+transformers@3.8.1/node_modules/sharp";
+
+function resolveSharpRuntime(): { version: string; packageLink: string } {
+  const require = createRequire(import.meta.url);
+  const transformersEntry = require.resolve("@huggingface/transformers");
+  const requireFromTransformers = createRequire(transformersEntry);
+  const sharpEntry = requireFromTransformers.resolve("sharp");
+  const manifest = JSON.parse(
+    readFileSync(join(dirname(sharpEntry), "..", "package.json"), "utf-8"),
+  ) as { name?: unknown; version?: unknown };
+  if (manifest.name !== "sharp" || typeof manifest.version !== "string") {
+    throw new Error("Unable to verify the application-owned Sharp package");
+  }
+  const transformersRoot = dirname(dirname(transformersEntry));
+  return {
+    version: manifest.version,
+    packageLink: join(dirname(dirname(transformersRoot)), "sharp"),
+  };
+}
 
 interface PlatformFiles {
   onnxDir: string;
@@ -115,28 +143,35 @@ const outDir = join("dist", platformKey);
 
 console.log(`Building for ${platformKey}...`);
 
-// 1. Stub sharp in node_modules so bun doesn't bundle native sharp
-let sharpOrigTarget: string | null = null;
-if (existsSync(SHARP_SYMLINK)) {
-  try {
-    sharpOrigTarget = readlinkSync(SHARP_SYMLINK);
-  } catch {
-    // not a symlink, might already be stubbed
-  }
-  rmSync(SHARP_SYMLINK, { recursive: true, force: true });
+// Resolve the real application-owned Sharp before replacing the Transformers
+// link with a text-only compile shim. Core receives and verifies this exact
+// version before it invokes the bundled Transformers loader.
+const pkgVersion = JSON.parse(readFileSync("package.json", "utf-8")).version;
+const { version: sharpVersion, packageLink: sharpPackageLink } = resolveSharpRuntime();
+if (!existsSync(sharpPackageLink)) {
+  throw new Error(`Transformers Sharp link is missing: ${sharpPackageLink}`);
 }
-mkdirSync(SHARP_SYMLINK, { recursive: true });
-Bun.write(join(SHARP_SYMLINK, "package.json"), JSON.stringify({ name: "sharp", version: "0.0.0", main: "index.js" }));
-Bun.write(join(SHARP_SYMLINK, "index.js"), "module.exports = {};");
+let sharpOrigTarget: string;
+try {
+  sharpOrigTarget = readlinkSync(sharpPackageLink);
+} catch {
+  throw new Error(`Refusing to replace non-symlink Sharp path: ${sharpPackageLink}`);
+}
+rmSync(sharpPackageLink);
+mkdirSync(sharpPackageLink, { recursive: true });
+Bun.write(
+  join(sharpPackageLink, "package.json"),
+  JSON.stringify({ name: "sharp", version: sharpVersion, main: "index.js" }),
+);
+Bun.write(join(sharpPackageLink, "index.js"), "module.exports = {};");
 
 try {
-  // 2. Compile (inject version at compile time via --define)
-  const pkgVersion = JSON.parse(readFileSync("package.json", "utf-8")).version;
   mkdirSync(outDir, { recursive: true });
   const outFile = join(outDir, platConfig.binaryName);
   const args = [
     "build", "--compile", "src/main.ts", "--outfile", outFile,
     "--define", `process.env.SKILL_ROUTER_VERSION='"${pkgVersion}"'`,
+    "--define", `MEMEX_BUNDLED_SHARP_VERSION='"${sharpVersion}"'`,
   ];
   if (targetFlag) {
     args.push("--target", targetFlag);
@@ -144,7 +179,7 @@ try {
 
   execSync(`bun ${args.join(" ")}`, { stdio: "inherit" });
 
-  // 3. Copy ONNX shared libraries alongside binary
+  // Copy ONNX shared libraries alongside binary.
   for (const lib of platConfig.sharedLibs) {
     const src = join(platConfig.onnxDir, lib);
     const dest = join(outDir, lib);
@@ -158,10 +193,7 @@ try {
 
   console.log(`\nBuild complete: ${outDir}/`);
 } finally {
-  // 4. Restore sharp symlink
-  rmSync(SHARP_SYMLINK, { recursive: true, force: true });
-  if (sharpOrigTarget) {
-    symlinkSync(sharpOrigTarget, SHARP_SYMLINK);
-    console.log("Restored sharp symlink");
-  }
+  rmSync(sharpPackageLink, { recursive: true, force: true });
+  symlinkSync(sharpOrigTarget, sharpPackageLink);
+  console.log("Restored sharp symlink");
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "bun run build.ts",
     "test": "vitest run",
+    "test:packaged-runtime": "pnpm build && bun run test/packaged-runtime-smoke.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,12 +22,19 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
-    "@jim80net/memex-core": "^0.7.1"
+    "@jim80net/memex-core": "^0.7.2"
+  },
+  "overrides": {
+    "protobufjs": "7.6.5",
+    "sharp": "0.35.3",
+    "tar": "7.5.21"
   },
   "packageManager": "pnpm@9.15.0",
   "pnpm": {
     "overrides": {
-      "sharp": "0.35.3"
+      "protobufjs": "7.6.5",
+      "sharp": "0.35.3",
+      "tar": "7.5.21"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
-    "@jim80net/memex-core": "^0.7.0"
+    "@jim80net/memex-core": "^0.7.1"
   },
   "packageManager": "pnpm@9.15.0",
   "pnpm": {
     "overrides": {
-      "sharp": "link:./stubs/sharp"
+      "sharp": "0.35.3"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  protobufjs: 7.6.5
   sharp: 0.35.3
+  tar: 7.5.21
 
 importers:
 
@@ -15,8 +17,8 @@ importers:
         specifier: ^3.8.1
         version: 3.8.1(@types/node@22.19.15)
       '@jim80net/memex-core':
-        specifier: ^0.7.1
-        version: 0.7.1(@types/node@22.19.15)
+        specifier: ^0.7.2
+        version: 0.7.2(@types/node@22.19.15)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -349,8 +351,8 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
-  '@jim80net/memex-core@0.7.1':
-    resolution: {integrity: sha512-WczqVO4PkNQmGUdX+XXPkeVRb4yH0wKPGMFgB4ff2fjz5YOQXBFD9bAmFwzH8v21OoW6Kz3JQ7lpEOpdbKQbaQ==}
+  '@jim80net/memex-core@0.7.2':
+    resolution: {integrity: sha512-pMmv6TWk+4NerdxRWTaAP4vQffu5GDS3+vCFP40JYmy8RxvlmrZFYhpfYsUl6Ni3Qfw/5xop0WC8r1D8Db4vCg==}
     hasBin: true
 
   '@jridgewell/sourcemap-codec@1.5.5':
@@ -362,20 +364,17 @@ packages:
   '@protobufjs/base64@1.1.2':
     resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
 
-  '@protobufjs/codegen@2.0.4':
-    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
 
-  '@protobufjs/fetch@1.1.0':
-    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
 
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
-
-  '@protobufjs/inquire@1.1.0':
-    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -383,8 +382,8 @@ packages:
   '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
 
-  '@protobufjs/utf8@1.1.0':
-    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
@@ -745,8 +744,8 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   resolve-pkg-maps@1.0.0:
@@ -806,8 +805,8 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
-  tar@7.5.11:
-    resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
+  tar@7.5.21:
+    resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}
     engines: {node: '>=18'}
 
   tinybench@2.9.0:
@@ -1140,7 +1139,7 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@jim80net/memex-core@0.7.1(@types/node@22.19.15)':
+  '@jim80net/memex-core@0.7.2(@types/node@22.19.15)':
     optionalDependencies:
       '@huggingface/transformers': 3.8.1(@types/node@22.19.15)
     transitivePeerDependencies:
@@ -1152,24 +1151,21 @@ snapshots:
 
   '@protobufjs/base64@1.1.2': {}
 
-  '@protobufjs/codegen@2.0.4': {}
+  '@protobufjs/codegen@2.0.5': {}
 
-  '@protobufjs/eventemitter@1.1.0': {}
+  '@protobufjs/eventemitter@1.1.1': {}
 
-  '@protobufjs/fetch@1.1.0':
+  '@protobufjs/fetch@1.1.1':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.0
 
   '@protobufjs/float@1.0.2': {}
-
-  '@protobufjs/inquire@1.1.0': {}
 
   '@protobufjs/path@1.1.2': {}
 
   '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.0': {}
+  '@protobufjs/utf8@1.1.2': {}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
@@ -1457,7 +1453,7 @@ snapshots:
     dependencies:
       global-agent: 3.0.0
       onnxruntime-common: 1.21.0
-      tar: 7.5.11
+      tar: 7.5.21
 
   onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
     dependencies:
@@ -1466,7 +1462,7 @@ snapshots:
       long: 5.3.2
       onnxruntime-common: 1.22.0-dev.20250409-89f8206ba4
       platform: 1.3.6
-      protobufjs: 7.5.4
+      protobufjs: 7.6.5
 
   pathe@2.0.3: {}
 
@@ -1484,18 +1480,17 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  protobufjs@7.5.4:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
+      '@protobufjs/utf8': 1.1.2
       '@types/node': 22.19.15
       long: 5.3.2
 
@@ -1598,7 +1593,7 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  tar@7.5.11:
+  tar@7.5.21:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  sharp: link:./stubs/sharp
+  sharp: 0.35.3
 
 importers:
 
@@ -13,10 +13,10 @@ importers:
     dependencies:
       '@huggingface/transformers':
         specifier: ^3.8.1
-        version: 3.8.1
+        version: 3.8.1(@types/node@22.19.15)
       '@jim80net/memex-core':
-        specifier: ^0.7.0
-        version: 0.7.0
+        specifier: ^0.7.1
+        version: 0.7.1(@types/node@22.19.15)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -32,6 +32,9 @@ importers:
         version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
 packages:
+
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
   '@esbuild/aix-ppc64@0.27.4':
     resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
@@ -196,12 +199,158 @@ packages:
   '@huggingface/transformers@3.8.1':
     resolution: {integrity: sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==}
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.35.3':
+    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.35.3':
+    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.35.3':
+    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.35.3':
+    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.35.3':
+    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.35.3':
+    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.35.3':
+    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.35.3':
+    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.35.3':
+    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.35.3':
+    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.35.3':
+    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.3':
+    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
-  '@jim80net/memex-core@0.7.0':
-    resolution: {integrity: sha512-qbEcRMSwPfz78rcrHns0Jaa2eBXEkVMqdzstW+cH/cmkuom/Ks6yaE6K06XYXtS40QSkFiOOEK4YPAWfJUkLJw==}
+  '@jim80net/memex-core@0.7.1':
+    resolution: {integrity: sha512-WczqVO4PkNQmGUdX+XXPkeVRb4yH0wKPGMFgB4ff2fjz5YOQXBFD9bAmFwzH8v21OoW6Kz3JQ7lpEOpdbKQbaQ==}
     hasBin: true
 
   '@jridgewell/sourcemap-codec@1.5.5':
@@ -448,6 +597,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
 
@@ -616,9 +769,23 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
+
+  sharp@0.35.3:
+    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -664,6 +831,9 @@ packages:
   tinyspy@4.0.4:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
@@ -766,6 +936,11 @@ packages:
 
 snapshots:
 
+  '@emnapi/runtime@1.11.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
@@ -846,20 +1021,130 @@ snapshots:
 
   '@huggingface/jinja@0.5.6': {}
 
-  '@huggingface/transformers@3.8.1':
+  '@huggingface/transformers@3.8.1(@types/node@22.19.15)':
     dependencies:
       '@huggingface/jinja': 0.5.6
       onnxruntime-node: 1.21.0
       onnxruntime-web: 1.22.0-dev.20250409-89f8206ba4
-      sharp: link:stubs/sharp
+      sharp: 0.35.3(@types/node@22.19.15)
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-darwin-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-s390x@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-wasm32@0.35.3':
+    dependencies:
+      '@emnapi/runtime': 1.11.2
+    optional: true
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.3':
+    optional: true
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
 
-  '@jim80net/memex-core@0.7.0':
+  '@jim80net/memex-core@0.7.1(@types/node@22.19.15)':
     optionalDependencies:
-      '@huggingface/transformers': 3.8.1
+      '@huggingface/transformers': 3.8.1(@types/node@22.19.15)
+    transitivePeerDependencies:
+      - '@types/node'
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -1051,6 +1336,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  detect-libc@2.1.2: {}
 
   detect-node@2.1.0: {}
 
@@ -1258,9 +1545,44 @@ snapshots:
 
   semver@7.7.4: {}
 
+  semver@7.8.5: {}
+
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
+
+  sharp@0.35.3(@types/node@22.19.15):
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.3
+      '@img/sharp-darwin-x64': 0.35.3
+      '@img/sharp-freebsd-wasm32': 0.35.3
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-linux-arm': 0.35.3
+      '@img/sharp-linux-arm64': 0.35.3
+      '@img/sharp-linux-ppc64': 0.35.3
+      '@img/sharp-linux-riscv64': 0.35.3
+      '@img/sharp-linux-s390x': 0.35.3
+      '@img/sharp-linux-x64': 0.35.3
+      '@img/sharp-linuxmusl-arm64': 0.35.3
+      '@img/sharp-linuxmusl-x64': 0.35.3
+      '@img/sharp-webcontainers-wasm32': 0.35.3
+      '@img/sharp-win32-arm64': 0.35.3
+      '@img/sharp-win32-ia32': 0.35.3
+      '@img/sharp-win32-x64': 0.35.3
+      '@types/node': 22.19.15
 
   siginfo@2.0.0: {}
 
@@ -1298,6 +1620,9 @@ snapshots:
   tinyrainbow@2.0.0: {}
 
   tinyspy@4.0.4: {}
+
+  tslib@2.8.1:
+    optional: true
 
   tsx@4.21.0:
     dependencies:

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,31 @@ import { handleStop } from "./hooks/stop.ts";
 import { handlePreToolUse } from "./hooks/pre-tool-use.ts";
 import { handleSessionStart } from "./hooks/session-start.ts";
 
+declare const MEMEX_BUNDLED_SHARP_VERSION: string;
+
+// Cross-release bridge while the Core resolver API is independently gated.
+// Remove this local constructor shape once the published Core declaration
+// includes LocalEmbeddingRuntimeResolver.
+type RuntimeAwareLocalEmbeddingProvider = new (
+  model?: string,
+  cacheDir?: string,
+  runtimeResolver?: {
+    resolveSharpVersion(): string;
+    loadTransformers(): Promise<unknown>;
+  },
+) => LocalEmbeddingProvider;
+
+const RuntimeAwareLocalEmbeddingProvider =
+  LocalEmbeddingProvider as unknown as RuntimeAwareLocalEmbeddingProvider;
+
+const bundledEmbeddingRuntime =
+  typeof MEMEX_BUNDLED_SHARP_VERSION === "string"
+    ? {
+        resolveSharpVersion: () => MEMEX_BUNDLED_SHARP_VERSION,
+        loadTransformers: () => import("@huggingface/transformers"),
+      }
+    : undefined;
+
 async function readStdin(): Promise<string> {
   const chunks: Buffer[] = [];
   for await (const chunk of process.stdin) {
@@ -69,7 +94,11 @@ async function main(): Promise<void> {
   }
 
   // Construct core objects
-  const provider = new LocalEmbeddingProvider(config.embeddingModel, paths.modelsDir);
+  const provider = new RuntimeAwareLocalEmbeddingProvider(
+    config.embeddingModel,
+    paths.modelsDir,
+    bundledEmbeddingRuntime,
+  );
   const cachePath = join(paths.cacheDir, "memex-cache.json");
 
   const scanDirs = await assembleClaudeScanDirs(

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,21 +13,6 @@ import { handleSessionStart } from "./hooks/session-start.ts";
 
 declare const MEMEX_BUNDLED_SHARP_VERSION: string;
 
-// Cross-release bridge while the Core resolver API is independently gated.
-// Remove this local constructor shape once the published Core declaration
-// includes LocalEmbeddingRuntimeResolver.
-type RuntimeAwareLocalEmbeddingProvider = new (
-  model?: string,
-  cacheDir?: string,
-  runtimeResolver?: {
-    resolveSharpVersion(): string;
-    loadTransformers(): Promise<unknown>;
-  },
-) => LocalEmbeddingProvider;
-
-const RuntimeAwareLocalEmbeddingProvider =
-  LocalEmbeddingProvider as unknown as RuntimeAwareLocalEmbeddingProvider;
-
 const bundledEmbeddingRuntime =
   typeof MEMEX_BUNDLED_SHARP_VERSION === "string"
     ? {
@@ -94,7 +79,7 @@ async function main(): Promise<void> {
   }
 
   // Construct core objects
-  const provider = new RuntimeAwareLocalEmbeddingProvider(
+  const provider = new LocalEmbeddingProvider(
     config.embeddingModel,
     paths.modelsDir,
     bundledEmbeddingRuntime,

--- a/test/cross-adapter-pin-alignment.test.ts
+++ b/test/cross-adapter-pin-alignment.test.ts
@@ -5,9 +5,11 @@ import { describe, expect, it } from "vitest";
 
 const CROSS_ADAPTER_TRANSFORMERS_RANGE = "^3.8.1";
 const CROSS_ADAPTER_TRANSFORMERS_RESOLVED = "3.8.1";
-const CROSS_ADAPTER_MEMEX_CORE_RANGE = "^0.7.1";
-const CROSS_ADAPTER_MEMEX_CORE_RESOLVED = "0.7.1";
+const CROSS_ADAPTER_MEMEX_CORE_RANGE = "^0.7.2";
+const CROSS_ADAPTER_MEMEX_CORE_RESOLVED = "0.7.2";
 const APPLICATION_SHARP_OVERRIDE = "0.35.3";
+const APPLICATION_PROTOBUFJS_OVERRIDE = "7.6.5";
+const APPLICATION_TAR_OVERRIDE = "7.5.21";
 
 function readJson(relFromRepoRoot: string): Record<string, unknown> {
   const url = new URL(`../${relFromRepoRoot}`, import.meta.url);
@@ -48,10 +50,16 @@ describe("cross-adapter version-pin alignment (memex-core#32)", () => {
   });
 
   it("the application owns one patched sharp runtime", () => {
+    const npmOverrides = claudePkg.overrides as Record<string, string> | undefined;
     const pnpm = claudePkg.pnpm as
       | { overrides?: Record<string, string> }
       | undefined;
+    expect(npmOverrides?.sharp).toBe(APPLICATION_SHARP_OVERRIDE);
+    expect(npmOverrides?.protobufjs).toBe(APPLICATION_PROTOBUFJS_OVERRIDE);
+    expect(npmOverrides?.tar).toBe(APPLICATION_TAR_OVERRIDE);
     expect(pnpm?.overrides?.sharp).toBe(APPLICATION_SHARP_OVERRIDE);
+    expect(pnpm?.overrides?.protobufjs).toBe(APPLICATION_PROTOBUFJS_OVERRIDE);
+    expect(pnpm?.overrides?.tar).toBe(APPLICATION_TAR_OVERRIDE);
 
     const storeDir = fileURLToPath(new URL("../node_modules/.pnpm", import.meta.url));
     const sharpEntries = readdirSync(storeDir)

--- a/test/cross-adapter-pin-alignment.test.ts
+++ b/test/cross-adapter-pin-alignment.test.ts
@@ -1,11 +1,13 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const CROSS_ADAPTER_TRANSFORMERS_RANGE = "^3.8.1";
 const CROSS_ADAPTER_TRANSFORMERS_RESOLVED = "3.8.1";
-const CROSS_ADAPTER_MEMEX_CORE_RANGE = "^0.7.0";
-const CROSS_ADAPTER_MEMEX_CORE_RESOLVED = "0.7.0";
+const CROSS_ADAPTER_MEMEX_CORE_RANGE = "^0.7.1";
+const CROSS_ADAPTER_MEMEX_CORE_RESOLVED = "0.7.1";
+const APPLICATION_SHARP_OVERRIDE = "0.35.3";
 
 function readJson(relFromRepoRoot: string): Record<string, unknown> {
   const url = new URL(`../${relFromRepoRoot}`, import.meta.url);
@@ -43,5 +45,29 @@ describe("cross-adapter version-pin alignment (memex-core#32)", () => {
     expect(CROSS_ADAPTER_TRANSFORMERS_RANGE).toBe(coreRange);
     const installed = readJson("node_modules/@huggingface/transformers/package.json");
     expect(installed.version).toBe(CROSS_ADAPTER_TRANSFORMERS_RESOLVED);
+  });
+
+  it("the application owns one patched sharp runtime", () => {
+    const pnpm = claudePkg.pnpm as
+      | { overrides?: Record<string, string> }
+      | undefined;
+    expect(pnpm?.overrides?.sharp).toBe(APPLICATION_SHARP_OVERRIDE);
+
+    const storeDir = fileURLToPath(new URL("../node_modules/.pnpm", import.meta.url));
+    const sharpEntries = readdirSync(storeDir)
+      .filter((entry) => entry.startsWith("sharp@"))
+      .sort();
+    expect(sharpEntries).toHaveLength(1);
+    expect(sharpEntries[0]).toMatch(
+      new RegExp(`^sharp@${APPLICATION_SHARP_OVERRIDE.replaceAll(".", "\\.")}(?:_|$)`),
+    );
+
+    const installed = JSON.parse(
+      readFileSync(
+        join(storeDir, sharpEntries[0]!, "node_modules", "sharp", "package.json"),
+        "utf-8",
+      ),
+    ) as { version?: unknown };
+    expect(installed.version).toBe(APPLICATION_SHARP_OVERRIDE);
   });
 });

--- a/test/packaged-runtime-smoke.ts
+++ b/test/packaged-runtime-smoke.ts
@@ -1,0 +1,88 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir, platform, arch } from "node:os";
+import { delimiter, join, resolve } from "node:path";
+
+const home = mkdtempSync(join(tmpdir(), "memex-claude-packaged-"));
+
+try {
+  const skillDir = join(home, ".claude", "skills", "packaged-smoke");
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, "SKILL.md"),
+    [
+      "---",
+      "name: packaged-smoke",
+      "description: Packaged runtime embedding smoke",
+      "---",
+      "",
+      "# Packaged runtime",
+      "",
+      "Proves a cold standalone index can generate a real embedding.",
+      "",
+    ].join("\n"),
+  );
+
+  const platformKey = `${platform()}-${arch()}`;
+  const outputDir = resolve("dist", platformKey);
+  const binary = join(outputDir, platform() === "win32" ? "memex.exe" : "memex");
+  const input = JSON.stringify({
+    hook_event_name: "UserPromptSubmit",
+    cwd: home,
+    prompt: "find the packaged runtime skill",
+  });
+  const env = {
+    ...process.env,
+    HOME: home,
+    LD_LIBRARY_PATH: [outputDir, process.env.LD_LIBRARY_PATH].filter(Boolean).join(delimiter),
+    PATH: [outputDir, process.env.PATH].filter(Boolean).join(delimiter),
+  };
+
+  const result = spawnSync(binary, {
+    input,
+    encoding: "utf-8",
+    env,
+    timeout: 120_000,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`packaged binary exited ${result.status}: ${result.stderr}`);
+  }
+  if (result.stderr.includes("index build failed")) {
+    throw new Error(`packaged cold index failed: ${result.stderr}`);
+  }
+
+  const cache = JSON.parse(
+    readFileSync(join(home, ".claude", "cache", "memex-cache.json"), "utf-8"),
+  ) as {
+    skills?: Record<string, { embeddings?: number[][] }>;
+  };
+  const entry = Object.values(cache.skills ?? {}).find(
+    (candidate) => candidate.embeddings?.length,
+  );
+  const embedding = entry?.embeddings?.[0];
+  if (
+    !embedding ||
+    embedding.length !== 384 ||
+    !embedding.every((value) => Number.isFinite(value))
+  ) {
+    throw new Error("packaged cold index did not persist one finite 384-dimensional embedding");
+  }
+
+  process.stdout.write(
+    `${JSON.stringify({
+      ok: true,
+      platform: platformKey,
+      embeddingDimensions: embedding.length,
+      stderr: result.stderr,
+    })}\n`,
+  );
+} finally {
+  rmSync(home, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Status

**READY FOR INDEPENDENT MERGE GATE.** This head resolves
[memex-claude #61](https://github.com/jim80net/memex-claude/issues/61) against
the published Core 0.7.2 runtime API. Do not release, deploy, or mutate the
installed plugin as part of this PR merge.

## What changed

- advances the application declaration and lock to published
  `@jim80net/memex-core@0.7.2` with registry integrity
  `sha512-pMmv6TWk+4NerdxRWTaAP4vQffu5GDS3+vCFP40JYmy8RxvlmrZFYhpfYsUl6Ni3Qfw/5xop0WC8r1D8Db4vCg==`;
- removes the temporary cross-release constructor bridge and uses the published
  `LocalEmbeddingRuntimeResolver` API;
- records the exact application-owned Sharp version before the Bun compile shim
  and supplies a lazy bundled Transformers loader;
- owns exact Sharp 0.35.3, tar 7.5.21, and protobufjs 7.6.5 resolutions;
- adds production audit and packaged cold-runtime regression coverage.

## Acceptance

- pnpm frozen install and production audit: pass, zero findings;
- one physical Sharp 0.35.3; Core 0.7.2 declaration/lock/install exact;
- vulnerable Sharp 0.34.5 rejected before the Transformers loader runs;
- typecheck and 60/60 tests pass;
- Bun standalone build and isolated packaged cold index pass with one finite
  384-dimensional embedding and empty stderr;
- hosted Linux Node 20/22, Windows Node 22, Claude review, and both Socket
  checks pass;
- no unresolved review threads.

Exact independently gated head:
`cb651bfc36bfe15bf91a375ef3426e2432f2c42e`.

## Boundary

Merge only. Release, deployment, and installed-plugin update require separate
exact-artifact acceptance.
