### PR TITLE
fix: report absolute handoff paths

### DIFF
--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -109,6 +109,12 @@ Everything that would be lost with the context window:
 
 Write to: `<cwd>/.claude/handoffs/<YYYYMMDD>-<kebab-case-title>.md`
 
+After the write succeeds, resolve **that exact file** to an absolute path and
+retain it as `<absolute-written-handoff-path>`. Use the current worktree's
+actual path (the platform-equivalent of resolving the written file with
+`realpath`); do not reconstruct the path from a later cwd, substitute a main
+checkout path, or assume the next session starts in this directory.
+
 Use this structure:
 
 ```markdown
@@ -197,7 +203,7 @@ Use this structure:
 
 ## To Resume
 
-1. Read this file: `cat .claude/handoffs/<filename>.md`
+1. Read this file: `cat <absolute-written-handoff-path>`
 2. <Verify state command>
 3. <First concrete action>
 ```
@@ -214,13 +220,21 @@ Update the file with any corrections.
 ### 9. Tell the user how to take over
 
 ```
-To continue, start a new session and say:
+Handoff written to:
 
-  /takeover .claude/handoffs/<YYYYMMDD>-<title>.md
+  <absolute-written-handoff-path>
+
+To continue in a fresh session:
+
+  /takeover <absolute-written-handoff-path>
 ```
 
 ## Guidelines
 
+- **Report the absolute path of the file actually written.** Reuse the same
+  `<absolute-written-handoff-path>` value in the completion and `/takeover`
+  command. This must remain valid from a different cwd, including when the
+  handoff was created inside a worktree.
 - **Spare no necessary detail.** The next session has zero context. Everything that matters must be written down. A long handoff that prevents hours of re-discovery is worth it.
 - **Be specific, not generic.** File paths, branch names, commit hashes, PR URLs, exact error messages, benchmark values, cost figures — anything the next session would need to look up, include directly.
 - **Explain the why.** Decisions without rationale will be re-evaluated from scratch.

--- a/test/handoff-skill.test.ts
+++ b/test/handoff-skill.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const skill = readFileSync(
+  join(repoRoot, "skills", "handoff", "SKILL.md"),
+  "utf-8",
+);
+const absolutePathToken = "<absolute-written-handoff-path>";
+
+function takeoverTemplate(): string {
+  const stepNine = skill.split("### 9. Tell the user how to take over")[1];
+  if (!stepNine) throw new Error("handoff step 9 is missing");
+
+  const block = stepNine.match(/```(?:text)?\n([\s\S]*?)\n```/)?.[1];
+  if (!block) throw new Error("handoff completion template is missing");
+  return block;
+}
+
+describe("/handoff absolute path contract", () => {
+  it("reports the exact written path and reuses it for /takeover", () => {
+    expect(skill).toContain("resolve **that exact file** to an absolute path");
+    expect(skill).toMatch(/current worktree's\s+actual path/);
+
+    const template = takeoverTemplate();
+    expect(template.match(new RegExp(absolutePathToken, "g"))).toHaveLength(2);
+    expect(template).toContain(`/takeover ${absolutePathToken}`);
+    expect(template).not.toContain("/takeover .claude/handoffs/");
+  });
+
+  it("renders a takeover command independent of the next session cwd", () => {
+    const roots = [
+      join(tmpdir(), "memex-handoff-contract", "main-checkout"),
+      join(
+        tmpdir(),
+        "memex-handoff-contract",
+        "main-checkout",
+        ".claude",
+        "worktrees",
+        "topic",
+      ),
+    ];
+    const unrelatedCwd = join(tmpdir(), "different-next-session-cwd");
+
+    for (const root of roots) {
+      const writtenPath = resolve(
+        root,
+        ".claude",
+        "handoffs",
+        "20260726-resume.md",
+      );
+      const rendered = takeoverTemplate().replaceAll(
+        absolutePathToken,
+        writtenPath,
+      );
+      const takeoverPath = rendered
+        .split("\n")
+        .find((line) => line.trimStart().startsWith("/takeover "))
+        ?.trim()
+        .slice("/takeover ".length);
+
+      expect(takeoverPath).toBe(writtenPath);
+      expect(isAbsolute(takeoverPath ?? "")).toBe(true);
+      expect(resolve(unrelatedCwd, takeoverPath ?? "")).toBe(writtenPath);
+    }
+  });
+});

--- a/test/handoff-skill.test.ts
+++ b/test/handoff-skill.test.ts
@@ -32,7 +32,8 @@ describe("/handoff absolute path contract", () => {
   });
 
   it("recognizes the completion contract after a CRLF checkout", () => {
-    const template = takeoverTemplate(skill.replaceAll("\n", "\r\n"));
+    const crlfSkill = skill.replaceAll("\r\n", "\n").replaceAll("\n", "\r\n");
+    const template = takeoverTemplate(crlfSkill);
 
     expect(template).toContain(`/takeover ${absolutePathToken}`);
   });

--- a/test/handoff-skill.test.ts
+++ b/test/handoff-skill.test.ts
@@ -11,11 +11,11 @@ const skill = readFileSync(
 );
 const absolutePathToken = "<absolute-written-handoff-path>";
 
-function takeoverTemplate(): string {
-  const stepNine = skill.split("### 9. Tell the user how to take over")[1];
+function takeoverTemplate(source = skill): string {
+  const stepNine = source.split("### 9. Tell the user how to take over")[1];
   if (!stepNine) throw new Error("handoff step 9 is missing");
 
-  const block = stepNine.match(/```(?:text)?\n([\s\S]*?)\n```/)?.[1];
+  const block = stepNine.match(/```(?:text)?\r?\n([\s\S]*?)\r?\n```/)?.[1];
   if (!block) throw new Error("handoff completion template is missing");
   return block;
 }
@@ -29,6 +29,12 @@ describe("/handoff absolute path contract", () => {
     expect(template.match(new RegExp(absolutePathToken, "g"))).toHaveLength(2);
     expect(template).toContain(`/takeover ${absolutePathToken}`);
     expect(template).not.toContain("/takeover .claude/handoffs/");
+  });
+
+  it("recognizes the completion contract after a CRLF checkout", () => {
+    const template = takeoverTemplate(skill.replaceAll("\n", "\r\n"));
+
+    expect(template).toContain(`/takeover ${absolutePathToken}`);
   });
 
   it("renders a takeover command independent of the next session cwd", () => {


### PR DESCRIPTION
## What changed

- retain the absolute path of the exact handoff file after it is written
- report that same path in the user-facing completion and suggested `/takeover` command
- preserve the worktree-local path instead of reconstructing a main-checkout or cwd-relative path
- use the absolute path in the handoff document's own resume instruction
- add regression coverage for normal-checkout and worktree-shaped paths when takeover begins from an unrelated cwd

## Why

`/handoff` currently writes the correct file but suggests a relative
`/takeover .claude/handoffs/...` command. That command fails whenever the next
session starts in a different worktree or directory. The completion contract
now reuses the actual file written, so takeover no longer depends on the next
session's cwd.

## User impact

Users can copy the suggested `/takeover` command into a fresh session from any
cwd, including another worktree, without another path-resolution round trip.

## Validation

- `pnpm typecheck`
- `pnpm test` — 63 passed
- `pnpm build`

Closes #49.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `/handoff` to return the absolute path of the written handoff file and use it in the suggested `/takeover` command, so takeover works from any cwd or worktree.

- **Bug Fixes**
  - Resolve and persist the worktree’s real path to the created handoff file; no path reconstruction from a later cwd or main checkout.
  - Update the “To Resume” step to `cat <absolute-written-handoff-path>` and show the same absolute path above the `/takeover` command.
  - Add tests and normalize line endings to ensure `<absolute-written-handoff-path>` is used, `/takeover` works from unrelated cwds/worktrees, and CRLF checkouts are recognized.

<sup>Written for commit ec86b5dcb4c0612c8abc879dac1e08698f2705da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jim80net/memex-claude/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->