### PR TITLE
ci: review Release Please pull requests

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,6 +37,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'github-actions[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
@@ -57,4 +58,3 @@ jobs:
             }
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-


### PR DESCRIPTION
## What changed

Allow only `github-actions[bot]` to pass the Claude review action's bot-author
guard.

## Why

Canonical Release Please PRs are authored by GitHub Actions. Their review
workflow was first held as `action_required`, then failed after approval
because the action rejects bot authors unless explicitly allowlisted. Using
the exact bot identity preserves fail-closed behavior for every other bot.

This must land on `main` before release PR #64 can be resynchronized: the
Claude action validates that its workflow is identical to the trusted
default-branch copy, so changing this workflow inside #64 produces a nominal
success that actually skips review.

## Validation

- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/claude-code-review.yml`
- Upstream action source confirms `allowed_bots` is comma-separated, strips
  the `[bot]` suffix for comparison, and keeps an empty default fail-closed.

## Scope

No product, version, release, deploy, or installed-plugin changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts bot authors to `github-actions[bot]` in the `anthropics/claude-code-action@v1` review workflow so Release Please PRs can pass review. Keeps other bots fail-closed.

<sup>Written for commit 0e42c8ad3a87e0e8b07885d87d6e377104fed8ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jim80net/memex-claude/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

