### PR TITLE
fix Windows Sharp release builds

### DIFF
--- a/.github/workflows/recover-release-assets.yml
+++ b/.github/workflows/recover-release-assets.yml
@@ -153,8 +153,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Stage independently reviewed recovery build driver
+        shell: bash
+        env:
+          MAIN_SHA: ${{ needs.preflight.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p build-support
+          git show "$MAIN_SHA:build.ts" > build.recovery.ts
+          git show "$MAIN_SHA:build-support/sharp-compile-shim.ts" > build-support/sharp-compile-shim.ts
+          echo "Building immutable tag source with recovery driver from main $MAIN_SHA"
+
       - name: Build binary
-        run: bun run build.ts --target ${{ matrix.bun-target }}
+        run: bun run build.recovery.ts --target ${{ matrix.bun-target }}
 
       - name: Package Unix artifact
         if: runner.os != 'Windows'

--- a/build-support/sharp-compile-shim.ts
+++ b/build-support/sharp-compile-shim.ts
@@ -1,0 +1,48 @@
+import {
+  existsSync,
+  mkdirSync,
+  readlinkSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Temporarily replace pnpm's Sharp symlink/junction with the text-only package
+ * Bun needs while compiling. Renaming preserves the original filesystem object
+ * verbatim and avoids Bun's Windows EFAULT when deleting directory junctions.
+ */
+export function installSharpCompileShim(
+  packageLink: string,
+  version: string,
+): () => void {
+  readlinkSync(packageLink);
+
+  const backupLink = `${packageLink}.memex-build-backup`;
+  if (existsSync(backupLink)) {
+    throw new Error(`Refusing to overwrite Sharp build backup: ${backupLink}`);
+  }
+
+  renameSync(packageLink, backupLink);
+  try {
+    mkdirSync(packageLink, { recursive: true });
+    writeFileSync(
+      join(packageLink, "package.json"),
+      JSON.stringify({ name: "sharp", version, main: "index.js" }),
+    );
+    writeFileSync(join(packageLink, "index.js"), "module.exports = {};");
+  } catch (error) {
+    rmSync(packageLink, { recursive: true, force: true });
+    renameSync(backupLink, packageLink);
+    throw error;
+  }
+
+  let restored = false;
+  return () => {
+    if (restored) return;
+    rmSync(packageLink, { recursive: true, force: true });
+    renameSync(backupLink, packageLink);
+    restored = true;
+  };
+}

--- a/build.ts
+++ b/build.ts
@@ -15,8 +15,6 @@
 import {
   mkdirSync,
   cpSync,
-  rmSync,
-  symlinkSync,
   readlinkSync,
   existsSync,
   readdirSync,
@@ -26,6 +24,7 @@ import { join, dirname } from "node:path";
 import { execSync } from "node:child_process";
 import { platform, arch } from "node:os";
 import { createRequire } from "node:module";
+import { installSharpCompileShim } from "./build-support/sharp-compile-shim";
 
 /** Resolve the ONNX runtime base path dynamically from node_modules. */
 function resolveOnnxBase(): string {
@@ -151,19 +150,12 @@ const { version: sharpVersion, packageLink: sharpPackageLink } = resolveSharpRun
 if (!existsSync(sharpPackageLink)) {
   throw new Error(`Transformers Sharp link is missing: ${sharpPackageLink}`);
 }
-let sharpOrigTarget: string;
 try {
-  sharpOrigTarget = readlinkSync(sharpPackageLink);
+  readlinkSync(sharpPackageLink);
 } catch {
   throw new Error(`Refusing to replace non-symlink Sharp path: ${sharpPackageLink}`);
 }
-rmSync(sharpPackageLink);
-mkdirSync(sharpPackageLink, { recursive: true });
-Bun.write(
-  join(sharpPackageLink, "package.json"),
-  JSON.stringify({ name: "sharp", version: sharpVersion, main: "index.js" }),
-);
-Bun.write(join(sharpPackageLink, "index.js"), "module.exports = {};");
+const restoreSharpLink = installSharpCompileShim(sharpPackageLink, sharpVersion);
 
 try {
   mkdirSync(outDir, { recursive: true });
@@ -193,7 +185,6 @@ try {
 
   console.log(`\nBuild complete: ${outDir}/`);
 } finally {
-  rmSync(sharpPackageLink, { recursive: true, force: true });
-  symlinkSync(sharpOrigTarget, sharpPackageLink);
+  restoreSharpLink();
   console.log("Restored sharp symlink");
 }

--- a/test/sharp-compile-shim.test.ts
+++ b/test/sharp-compile-shim.test.ts
@@ -1,0 +1,52 @@
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { installSharpCompileShim } from "../build-support/sharp-compile-shim";
+
+describe("Sharp compile shim", () => {
+  const cleanup: string[] = [];
+
+  afterEach(() => {
+    for (const path of cleanup.splice(0)) {
+      rmSync(path, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves and restores the original package link", () => {
+    const root = mkdtempSync(join(tmpdir(), "memex-sharp-shim-"));
+    cleanup.push(root);
+    const target = join(root, "sharp-target");
+    const packageLink = join(root, "sharp");
+    mkdirSync(target);
+    symlinkSync(
+      target,
+      packageLink,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    const originalTarget = readlinkSync(packageLink);
+
+    const restore = installSharpCompileShim(packageLink, "0.35.3");
+
+    expect(
+      JSON.parse(readFileSync(join(packageLink, "package.json"), "utf8")),
+    ).toEqual({ name: "sharp", version: "0.35.3", main: "index.js" });
+    expect(readFileSync(join(packageLink, "index.js"), "utf8")).toBe(
+      "module.exports = {};",
+    );
+
+    restore();
+    expect(readlinkSync(packageLink)).toBe(originalTarget);
+
+    // Cleanup paths stay valid if a caller defensively restores twice.
+    restore();
+    expect(readlinkSync(packageLink)).toBe(originalTarget);
+  });
+});


### PR DESCRIPTION
## Summary

- preserve pnpm's Sharp link/junction by renaming it aside during Bun compilation instead of deleting and recreating it
- cover the swap/restore behavior with a cross-platform regression test
- make existing-tag recovery compile immutable tag source with the independently reviewed build driver from current main

## Root cause

The v1.9.1 Release Please run passed tests on every platform and built Linux/macOS successfully, but Bun 1.3.14 on Windows reproducibly returns `EFAULT` when `rmSync` deletes the pnpm Sharp directory junction. Publish remains skipped and the v1.9.1 release has no completed asset set.

Renaming preserves the original junction verbatim and avoids the failing deletion path. Recovery continues to verify and check out the immutable tag for product source; only the build driver is staged from the exact tested main SHA.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm tsc --noEmit`
- `pnpm test` — 64/64
- `bun run build.ts --target bun-linux-x64`
- `pnpm audit --prod --audit-level high` — 0
- exactly one runtime Sharp 0.35.3 package in the pnpm graph

## Release safety

No tag mutation, asset overwrite, release publish, or plugin install is performed by this PR. After independent merge, dispatch the existing release recovery workflow for `v1.9.1`; it remains fail-closed on tag drift and asset collisions.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows release builds by preserving `pnpm`’s `sharp` junction during Bun compile. This avoids EFAULT failures on Windows and unblocks v1.9.1 asset recovery.

- **Bug Fixes**
  - Swap the `sharp` symlink/junction by renaming it and installing a stub, then restore it after build.
  - Extracted `installSharpCompileShim` to handle swap/restore safely.
  - Added cross-platform test for the shim behavior.
  - Updated recovery workflow to build immutable tag source using the reviewed `build.ts` and new shim from `main`.

- **Migration**
  - After merge, run the existing release recovery workflow for `v1.9.1`.

<sup>Written for commit c7a9a6947261d111df04b701f9f57905e665b89b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jim80net/memex-claude/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

