### PR TITLE
fix stale doctor pin and automate installed verification

### DIFF
--- a/docs/installed-verifier.md
+++ b/docs/installed-verifier.md
@@ -1,0 +1,28 @@
+# Read-only installed verifier
+
+`verify:installed` replaces the repeated manual installed-plugin audit with one
+fail-closed command. It does not invoke Claude, authenticate, update the plugin,
+download assets, or write to the plugin cache.
+
+```bash
+pnpm verify:installed -- \
+  --source-root /path/to/immutable/v1.9.1-checkout \
+  --release-dir /path/to/downloaded/v1.9.1-assets
+```
+
+The source root is required and must be an immutable release-tag checkout. The
+release directory is optional; when supplied it must contain `checksums.txt`
+and the complete artifact set named by that file.
+
+The verifier discovers the single enabled user-scope
+`memex-claude@jim80net-plugins` record below `~/.claude` and checks:
+
+- registry, installed package, plugin manifest, and immutable-source versions;
+- SHA-256 equality for package/plugin metadata, handoff/takeover skills, and
+  the handoff regression;
+- every release artifact against `checksums.txt`, with no undeclared files;
+- the installed `/handoff` completion template's exact absolute path reuse from
+  unrelated normal-checkout and worktree-shaped current directories.
+
+Use `--claude-home <path>` for an isolated fixture or non-default Claude home.
+The command writes a JSON report to stdout and exits nonzero on any drift.

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
   "type": "module",
   "scripts": {
     "build": "bun run build.ts",
+    "inspect:core-pin": "node scripts/inspect-core-pin.mjs",
     "test": "vitest run",
     "test:packaged-runtime": "pnpm build && bun run test/packaged-runtime-smoke.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "verify:installed": "node scripts/verify-installed.mjs"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/scripts/inspect-core-pin.mjs
+++ b/scripts/inspect-core-pin.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const CORE_PACKAGE = "@jim80net/memex-core";
+
+function parseArgs(argv) {
+  let root = process.cwd();
+  let json = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--root") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("--root requires a path");
+      root = value;
+      index += 1;
+    } else if (argument === "--json") {
+      json = true;
+    } else {
+      throw new Error(`unknown argument: ${argument}`);
+    }
+  }
+
+  return { root: resolve(root), json };
+}
+
+export function inspectCorePin(root) {
+  const packageJson = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+  const declaration = packageJson.dependencies?.[CORE_PACKAGE];
+  if (typeof declaration !== "string" || declaration.length === 0) {
+    throw new Error(`${CORE_PACKAGE} is missing from package.json dependencies`);
+  }
+
+  const lockLines = readFileSync(resolve(root, "pnpm-lock.yaml"), "utf8").split(/\r?\n/);
+  const dependencyLine = lockLines.findIndex(
+    (line) => line.trim() === `'${CORE_PACKAGE}':`,
+  );
+  if (dependencyLine < 0) {
+    throw new Error(`${CORE_PACKAGE} is missing from the pnpm lock importer`);
+  }
+
+  const importerLines = lockLines.slice(dependencyLine + 1, dependencyLine + 5);
+  const specifier = importerLines
+    .find((line) => line.trimStart().startsWith("specifier:"))
+    ?.split(":")
+    .slice(1)
+    .join(":")
+    .trim();
+  const lockValue = importerLines
+    .find((line) => line.trimStart().startsWith("version:"))
+    ?.split(":")
+    .slice(1)
+    .join(":")
+    .trim();
+
+  if (!specifier || !lockValue) {
+    throw new Error(`cannot read ${CORE_PACKAGE} specifier/version from the pnpm lock importer`);
+  }
+  if (specifier !== declaration) {
+    throw new Error(
+      `${CORE_PACKAGE} drift: package.json declares ${declaration}, lock importer declares ${specifier}`,
+    );
+  }
+
+  return {
+    package: CORE_PACKAGE,
+    declaration,
+    resolvedVersion: lockValue.replace(/\(.*/, ""),
+    lockValue,
+  };
+}
+
+function main() {
+  try {
+    const { root, json } = parseArgs(process.argv.slice(2));
+    const result = inspectCorePin(root);
+    if (json) {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    } else {
+      process.stdout.write(
+        `${result.package}: declaration ${result.declaration}; lock resolution ${result.resolvedVersion}\n`,
+      );
+    }
+  } catch (error) {
+    process.stderr.write(`memex core pin check failed: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) main();

--- a/scripts/verify-installed.mjs
+++ b/scripts/verify-installed.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { basename, isAbsolute, join, resolve } from "node:path";
+
+const PLUGIN_ID = "memex-claude@jim80net-plugins";
+const COMPARED_FILES = [
+  "package.json",
+  ".claude-plugin/plugin.json",
+  "skills/handoff/SKILL.md",
+  "skills/takeover/SKILL.md",
+  "test/handoff-skill.test.ts",
+];
+const HANDOFF_TOKEN = "<absolute-written-handoff-path>";
+
+function parseArgs(argv) {
+  const options = {
+    claudeHome: join(homedir(), ".claude"),
+    sourceRoot: undefined,
+    releaseDir: undefined,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--claude-home") {
+      options.claudeHome = requireValue(argv, ++index, argument);
+    } else if (argument === "--source-root") {
+      options.sourceRoot = requireValue(argv, ++index, argument);
+    } else if (argument === "--release-dir") {
+      options.releaseDir = requireValue(argv, ++index, argument);
+    } else {
+      throw new Error(`unknown argument: ${argument}`);
+    }
+  }
+
+  if (!options.sourceRoot) {
+    throw new Error("--source-root is required (use an immutable release-tag checkout)");
+  }
+  return options;
+}
+
+function requireValue(argv, index, argument) {
+  const value = argv[index];
+  if (!value) throw new Error(`${argument} requires a path`);
+  return value;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function sha256(path) {
+  const hash = createHash("sha256");
+  const descriptor = openSync(path, "r");
+  const buffer = Buffer.allocUnsafe(1024 * 1024);
+  try {
+    let bytesRead = 0;
+    do {
+      bytesRead = readSync(descriptor, buffer, 0, buffer.length, null);
+      if (bytesRead > 0) hash.update(buffer.subarray(0, bytesRead));
+    } while (bytesRead > 0);
+  } finally {
+    closeSync(descriptor);
+  }
+  return hash.digest("hex");
+}
+
+function check(report, name, ok, detail) {
+  report.checks.push({ name, ok, detail });
+  if (!ok) report.failures.push(`${name}: ${detail}`);
+}
+
+function discoverInstalled(claudeHome, report) {
+  const settings = readJson(join(claudeHome, "settings.json"));
+  check(
+    report,
+    "plugin enabled",
+    settings.enabledPlugins?.[PLUGIN_ID] === true,
+    `settings enabledPlugins[${PLUGIN_ID}] must be true`,
+  );
+
+  const registry = readJson(join(claudeHome, "plugins", "installed_plugins.json"));
+  const userRecords = (registry.plugins?.[PLUGIN_ID] ?? []).filter(
+    (record) => record.scope === "user",
+  );
+  check(
+    report,
+    "single user-scope installation",
+    userRecords.length === 1,
+    `found ${userRecords.length} user-scope records`,
+  );
+  if (userRecords.length !== 1) return undefined;
+
+  const record = userRecords[0];
+  const root = realpathSync(record.installPath);
+  check(
+    report,
+    "registry install path",
+    isAbsolute(record.installPath) && statSync(root).isDirectory(),
+    record.installPath,
+  );
+  return { record, root };
+}
+
+function verifyVersions(installed, sourceRoot, report) {
+  const installedPackage = readJson(join(installed.root, "package.json"));
+  const installedPlugin = readJson(join(installed.root, ".claude-plugin", "plugin.json"));
+  const sourcePackage = readJson(join(sourceRoot, "package.json"));
+  const sourcePlugin = readJson(join(sourceRoot, ".claude-plugin", "plugin.json"));
+  const versions = {
+    registry: installed.record.version,
+    installedPackage: installedPackage.version,
+    installedPlugin: installedPlugin.version,
+    sourcePackage: sourcePackage.version,
+    sourcePlugin: sourcePlugin.version,
+  };
+  const unique = new Set(Object.values(versions));
+  check(report, "version alignment", unique.size === 1, JSON.stringify(versions));
+  report.version = sourcePackage.version;
+}
+
+function verifySourceHashes(installedRoot, sourceRoot, report) {
+  report.files = [];
+  for (const relativePath of COMPARED_FILES) {
+    const installedPath = join(installedRoot, relativePath);
+    const sourcePath = join(sourceRoot, relativePath);
+    const present = existsSync(installedPath) && existsSync(sourcePath);
+    if (!present) {
+      check(report, `source hash ${relativePath}`, false, "file missing from installed or source root");
+      continue;
+    }
+    const installedHash = sha256(installedPath);
+    const sourceHash = sha256(sourcePath);
+    report.files.push({ path: relativePath, sha256: installedHash });
+    check(
+      report,
+      `source hash ${relativePath}`,
+      installedHash === sourceHash,
+      `${installedHash} installed; ${sourceHash} source`,
+    );
+  }
+}
+
+function completionTemplate(skill) {
+  const stepNine = skill.split("### 9. Tell the user how to take over")[1];
+  if (!stepNine) throw new Error("handoff step 9 is missing");
+  const block = stepNine.match(/```(?:text)?\r?\n([\s\S]*?)\r?\n```/)?.[1];
+  if (!block) throw new Error("handoff completion template is missing");
+  return block;
+}
+
+function verifyHandoff(installedRoot, report) {
+  try {
+    const skill = readFileSync(join(installedRoot, "skills", "handoff", "SKILL.md"), "utf8");
+    const template = completionTemplate(skill);
+    const tokenCount = template.split(HANDOFF_TOKEN).length - 1;
+    const contractPresent =
+      skill.includes("resolve **that exact file** to an absolute path") &&
+      tokenCount === 2 &&
+      template.includes(`/takeover ${HANDOFF_TOKEN}`) &&
+      !template.includes("/takeover .claude/handoffs/");
+    check(report, "absolute handoff contract", contractPresent, `token occurrences: ${tokenCount}`);
+
+    const unrelatedCwd = join(tmpdir(), "memex-unrelated-next-session-cwd");
+    for (const root of [
+      join(tmpdir(), "memex-handoff", "main"),
+      join(tmpdir(), "memex-handoff", "main", ".claude", "worktrees", "topic"),
+    ]) {
+      const writtenPath = resolve(root, ".claude", "handoffs", "resume.md");
+      const rendered = template.replaceAll(HANDOFF_TOKEN, writtenPath);
+      const takeoverPath = rendered
+        .split(/\r?\n/)
+        .find((line) => line.trimStart().startsWith("/takeover "))
+        ?.trim()
+        .slice("/takeover ".length);
+      check(
+        report,
+        `unrelated-cwd handoff ${basename(root)}`,
+        takeoverPath === writtenPath && isAbsolute(takeoverPath ?? "") &&
+          resolve(unrelatedCwd, takeoverPath ?? "") === writtenPath,
+        takeoverPath ?? "missing /takeover command",
+      );
+    }
+  } catch (error) {
+    check(
+      report,
+      "absolute handoff contract",
+      false,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+function parseChecksums(path) {
+  const entries = new Map();
+  for (const [index, line] of readFileSync(path, "utf8").split(/\r?\n/).entries()) {
+    if (!line.trim()) continue;
+    const match = line.match(/^([a-fA-F0-9]{64})\s+\*?(.+)$/);
+    if (!match) throw new Error(`invalid checksums.txt line ${index + 1}`);
+    const name = match[2];
+    if (basename(name) !== name || name === "." || name === "..") {
+      throw new Error(`unsafe checksum asset name: ${name}`);
+    }
+    if (entries.has(name)) throw new Error(`duplicate checksum asset: ${name}`);
+    entries.set(name, match[1].toLowerCase());
+  }
+  if (entries.size === 0) throw new Error("checksums.txt contains no assets");
+  return entries;
+}
+
+function verifyRelease(releaseDir, report) {
+  try {
+    const checksumsPath = join(releaseDir, "checksums.txt");
+    const entries = parseChecksums(checksumsPath);
+    for (const [name, expected] of entries) {
+      const assetPath = join(releaseDir, name);
+      const actual = existsSync(assetPath) ? sha256(assetPath) : "missing";
+      check(report, `release checksum ${name}`, actual === expected, `${actual}; expected ${expected}`);
+    }
+    const extras = readdirSync(releaseDir)
+      .filter((name) => name !== "checksums.txt" && !name.startsWith("."))
+      .filter((name) => !entries.has(name));
+    check(report, "release artifact inventory", extras.length === 0, `unexpected: ${extras.join(", ") || "none"}`);
+    report.release = {
+      directory: realpathSync(releaseDir),
+      checksumsSha256: sha256(checksumsPath),
+      artifacts: [...entries.keys()],
+    };
+  } catch (error) {
+    check(
+      report,
+      "release checksums",
+      false,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+function main() {
+  const report = {
+    ok: false,
+    pluginId: PLUGIN_ID,
+    mode: "read-only",
+    checks: [],
+    failures: [],
+  };
+
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const sourceRoot = realpathSync(options.sourceRoot);
+    const installed = discoverInstalled(resolve(options.claudeHome), report);
+    if (installed) {
+      report.installPath = installed.root;
+      verifyVersions(installed, sourceRoot, report);
+      verifySourceHashes(installed.root, sourceRoot, report);
+      verifyHandoff(installed.root, report);
+    }
+    if (options.releaseDir) verifyRelease(realpathSync(options.releaseDir), report);
+  } catch (error) {
+    report.failures.push(error instanceof Error ? error.message : String(error));
+  }
+
+  report.ok = report.failures.length === 0;
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  if (!report.ok) process.exitCode = 1;
+}
+
+main();

--- a/scripts/verify-installed.mjs
+++ b/scripts/verify-installed.mjs
@@ -229,7 +229,7 @@ function verifyRelease(releaseDir, report) {
       check(report, `release checksum ${name}`, actual === expected, `${actual}; expected ${expected}`);
     }
     const extras = readdirSync(releaseDir)
-      .filter((name) => name !== "checksums.txt" && !name.startsWith("."))
+      .filter((name) => name !== "checksums.txt")
       .filter((name) => !entries.has(name));
     check(report, "release artifact inventory", extras.length === 0, `unexpected: ${extras.join(", ") || "none"}`);
     report.release = {

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -124,9 +124,8 @@ ls ~/.claude/projects/*/memory/*.md 2>/dev/null
 When `sync.enabled: true` in `~/.claude/memex.json`, memex projects origin rules into `~/.claude/rules` as **symlinks** (fail-closed; never overwrites real files).
 
 ```bash
-# Pin (expect @jim80net/memex-core ^0.6.0)
-node -e "console.log(require('./node_modules/@jim80net/memex-core/package.json').version)" 2>/dev/null \
-  || cat node_modules/@jim80net/memex-core/package.json 2>/dev/null | head -5
+# Core declaration + exact lock resolution (derived; no version literal)
+node "$PLUGIN_ROOT/scripts/inspect-core-pin.mjs" --root "$PLUGIN_ROOT"
 
 # Effective origin (resolver: ~/.memex → XDG → legacy-claude)
 ls -la ~/.memex/rules 2>/dev/null | head

--- a/test/core-pin-script.test.ts
+++ b/test/core-pin-script.test.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const script = join(repoRoot, "scripts", "inspect-core-pin.mjs");
+const cleanup: string[] = [];
+
+function fixture(specifier = "^0.7.2") {
+  const root = mkdtempSync(join(tmpdir(), "memex-core-pin-"));
+  cleanup.push(root);
+  mkdirSync(root, { recursive: true });
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify({ dependencies: { "@jim80net/memex-core": "^0.7.2" } }),
+  );
+  writeFileSync(
+    join(root, "pnpm-lock.yaml"),
+    `lockfileVersion: '9.0'\nimporters:\n  .:\n    dependencies:\n      '@jim80net/memex-core':\n        specifier: ${specifier}\n        version: 0.7.2(@types/node@22.0.0)\n`,
+  );
+  return root;
+}
+
+afterEach(() => {
+  for (const path of cleanup.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe("Core pin inspector", () => {
+  it("derives declaration and exact resolution from manifest and lock", () => {
+    const result = spawnSync(process.execPath, [script, "--root", fixture(), "--json"], {
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      package: "@jim80net/memex-core",
+      declaration: "^0.7.2",
+      resolvedVersion: "0.7.2",
+    });
+  });
+
+  it("fails closed when manifest and lock declarations drift", () => {
+    const result = spawnSync(process.execPath, [script, "--root", fixture("^0.8.0")], {
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("package.json declares ^0.7.2");
+  });
+
+  it("keeps the doctor skill free of a hard-coded Core expectation", () => {
+    const doctor = readFileSync(join(repoRoot, "skills", "doctor", "SKILL.md"), "utf8");
+    expect(doctor).toContain('inspect-core-pin.mjs" --root "$PLUGIN_ROOT"');
+    expect(doctor).not.toMatch(/expect @jim80net\/memex-core/);
+  });
+});

--- a/test/installed-verifier.test.ts
+++ b/test/installed-verifier.test.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
 import {
-  cpSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -139,6 +138,17 @@ describe("read-only installed verifier", () => {
     const result = run(fixture);
     expect(result.status).toBe(1);
     expect(result.report.failures.join("\n")).toContain("release checksum memex-linux-x64.tar.gz");
+  });
+
+  it("fails on an undeclared hidden release artifact", () => {
+    const fixture = createFixture();
+    writeFileSync(join(fixture.releaseDir, ".undeclared"), "hostile metadata\n");
+    const result = run(fixture);
+    expect(result.status).toBe(1);
+    expect(result.report).toMatchObject({ ok: false });
+    expect(result.report.failures.join("\n")).toContain(
+      "release artifact inventory: unexpected: .undeclared",
+    );
   });
 
   it("fails on an absolute handoff contract regression even when source matches", () => {

--- a/test/installed-verifier.test.ts
+++ b/test/installed-verifier.test.ts
@@ -1,0 +1,156 @@
+import { createHash } from "node:crypto";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const script = join(repoRoot, "scripts", "verify-installed.mjs");
+const cleanup: string[] = [];
+
+const validHandoff = `### 7. Write the handoff file\nresolve **that exact file** to an absolute path\n\n### 9. Tell the user how to take over\n\n\`\`\`text\nWritten: <absolute-written-handoff-path>\n/takeover <absolute-written-handoff-path>\n\`\`\`\n`;
+
+function sha256(path: string) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function createFixture() {
+  const root = mkdtempSync(join(tmpdir(), "memex-installed-verifier-"));
+  cleanup.push(root);
+  const claudeHome = join(root, "claude");
+  const sourceRoot = join(root, "source");
+  const installedRoot = join(root, "installed");
+  const releaseDir = join(root, "release");
+
+  for (const target of [sourceRoot, installedRoot]) {
+    mkdirSync(join(target, ".claude-plugin"), { recursive: true });
+    mkdirSync(join(target, "skills", "handoff"), { recursive: true });
+    mkdirSync(join(target, "skills", "takeover"), { recursive: true });
+    mkdirSync(join(target, "test"), { recursive: true });
+    writeFileSync(join(target, "package.json"), JSON.stringify({ name: "memex-claude", version: "1.9.1" }));
+    writeFileSync(join(target, ".claude-plugin", "plugin.json"), JSON.stringify({ name: "memex-claude", version: "1.9.1" }));
+    writeFileSync(join(target, "skills", "handoff", "SKILL.md"), validHandoff);
+    writeFileSync(join(target, "skills", "takeover", "SKILL.md"), "takeover\n");
+    writeFileSync(join(target, "test", "handoff-skill.test.ts"), "handoff regression\n");
+  }
+
+  mkdirSync(join(claudeHome, "plugins"), { recursive: true });
+  writeFileSync(
+    join(claudeHome, "settings.json"),
+    JSON.stringify({ enabledPlugins: { "memex-claude@jim80net-plugins": true } }),
+  );
+  writeFileSync(
+    join(claudeHome, "plugins", "installed_plugins.json"),
+    JSON.stringify({
+      version: 2,
+      plugins: {
+        "memex-claude@jim80net-plugins": [
+          { scope: "user", installPath: installedRoot, version: "1.9.1" },
+        ],
+      },
+    }),
+  );
+
+  mkdirSync(releaseDir);
+  writeFileSync(join(releaseDir, "memex-linux-x64.tar.gz"), "release asset\n");
+  writeFileSync(
+    join(releaseDir, "checksums.txt"),
+    `${sha256(join(releaseDir, "memex-linux-x64.tar.gz"))}  memex-linux-x64.tar.gz\n`,
+  );
+
+  return { root, claudeHome, sourceRoot, installedRoot, releaseDir };
+}
+
+function run(fixture: ReturnType<typeof createFixture>) {
+  const result = spawnSync(
+    process.execPath,
+    [
+      script,
+      "--claude-home",
+      fixture.claudeHome,
+      "--source-root",
+      fixture.sourceRoot,
+      "--release-dir",
+      fixture.releaseDir,
+    ],
+    { encoding: "utf8" },
+  );
+  return { ...result, report: JSON.parse(result.stdout) };
+}
+
+function snapshot(root: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  function visit(path: string, relative = "") {
+    for (const name of readdirSync(path).sort()) {
+      const child = join(path, name);
+      const childRelative = join(relative, name);
+      if (statSync(child).isDirectory()) visit(child, childRelative);
+      else result[childRelative] = sha256(child);
+    }
+  }
+  visit(root);
+  return result;
+}
+
+afterEach(() => {
+  for (const path of cleanup.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe("read-only installed verifier", () => {
+  it("passes aligned version, source hashes, checksums, and absolute handoff", () => {
+    const fixture = createFixture();
+    const before = snapshot(fixture.root);
+    const result = run(fixture);
+    expect(result.status).toBe(0);
+    expect(result.report).toMatchObject({ ok: true, version: "1.9.1", mode: "read-only" });
+    expect(snapshot(fixture.root)).toEqual(before);
+  });
+
+  it("fails on installed version drift", () => {
+    const fixture = createFixture();
+    writeFileSync(join(fixture.installedRoot, "package.json"), JSON.stringify({ name: "memex-claude", version: "1.9.0" }));
+    const result = run(fixture);
+    expect(result.status).toBe(1);
+    expect(result.report.failures.join("\n")).toContain("version alignment");
+  });
+
+  it("fails on installed source hash drift", () => {
+    const fixture = createFixture();
+    writeFileSync(join(fixture.installedRoot, "skills", "takeover", "SKILL.md"), "drift\n");
+    const result = run(fixture);
+    expect(result.status).toBe(1);
+    expect(result.report.failures.join("\n")).toContain("source hash skills/takeover/SKILL.md");
+  });
+
+  it("fails on release checksum drift", () => {
+    const fixture = createFixture();
+    writeFileSync(join(fixture.releaseDir, "memex-linux-x64.tar.gz"), "tampered\n");
+    const result = run(fixture);
+    expect(result.status).toBe(1);
+    expect(result.report.failures.join("\n")).toContain("release checksum memex-linux-x64.tar.gz");
+  });
+
+  it("fails on an absolute handoff contract regression even when source matches", () => {
+    const fixture = createFixture();
+    const relative = validHandoff
+      .replaceAll("<absolute-written-handoff-path>", ".claude/handoffs/resume.md")
+      .replace("resolve **that exact file** to an absolute path", "write the handoff");
+    for (const root of [fixture.sourceRoot, fixture.installedRoot]) {
+      writeFileSync(join(root, "skills", "handoff", "SKILL.md"), relative);
+    }
+    const result = run(fixture);
+    expect(result.status).toBe(1);
+    expect(result.report.failures.join("\n")).toContain("absolute handoff contract");
+  });
+});


### PR DESCRIPTION
## What changed

- replace the stale hard-coded Core `^0.6.0` doctor expectation with a read-only
  inspector that derives the declaration and exact resolution from
  `package.json` and `pnpm-lock.yaml`
- add a dependency-free `verify:installed` command that discovers the enabled
  user-scope plugin and fails closed on version, immutable-source hash, release
  checksum/inventory, or absolute `/handoff` → `/takeover` drift
- document the command's immutable-source and optional complete-release-directory
  inputs
- add regression coverage for success, no-write behavior, and every drift class

## Why

The doctor skill became stale each time Core advanced, while the installed-plugin
audit was repeatedly reconstructed by hand during nightly walks. Both procedures
now derive their truth from durable inputs and produce machine-readable evidence
without invoking Claude, authenticating, downloading, installing, updating, or
writing to the plugin cache.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm test` — 72/72
- `pnpm build` — linux-arm64 standalone build
- `pnpm audit --prod --audit-level low` — 0 findings
- focused verifier tests — 8/8
- live read-only verifier against enabled 1.9.1 cache and identical immutable
  cached source — pass
- `git diff --check`

## Safety

Draft for independent review. No release, plugin install/update, restart, Claude
invocation, authentication/Auth Domains action, or deployment was performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the hard-coded Core pin in the doctor skill with a derived inspector, and added a read-only installed verifier to catch drift without touching the plugin cache. The verifier also rejects undeclared hidden release artifacts (dotfiles) while automating version, hash, checksum, and absolute handoff checks.

- **New Features**
  - `inspect:core-pin` via `scripts/inspect-core-pin.mjs`: derives the `@jim80net/memex-core` declaration from `package.json` and exact resolution from `pnpm-lock.yaml`; the doctor skill now prints this instead of a pinned literal.
  - `verify:installed` via `scripts/verify-installed.mjs`: audits the enabled `memex-claude@jim80net-plugins` against an immutable source checkout (and optional release dir). Checks registry/manifest versions, SHA-256 of key files, release checksums and inventory (rejects undeclared dotfiles), and absolute `/handoff` → `/takeover` path reuse. Prints a JSON report and exits non-zero on drift. Read-only; no auth, downloads, installs, or writes.
  - Added `docs/installed-verifier.md` and tests covering success, drift, and hidden artifact cases.

<sup>Written for commit 2c5282f40833db35776021258f1ea9d306232790. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jim80net/memex-claude/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

